### PR TITLE
 Fix: for yet-unknown-reasons 'bundle install' no longer installs http_parser.rb and safe_yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,14 @@ COPY Gemfile Gemfile.lock /source/
 RUN apk --no-cache add \
         build-base \
         ruby \
+        ruby-bigdecimal \
         ruby-dev \
+        ruby-json \
         ruby-rdoc \
-    && gem update --no-document --system \
-    && gem install --no-document \
-        bigdecimal \
-        json \
-        -- --use-system-libraries \
+    && echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc \
+    && gem update --system \
+    && gem install http_parser.rb -v 0.6.0 -- --use-system-libraries \
+    && gem install safe_yaml -v 1.0.4 -- --use-system-libraries \
     && bundle install \
     && apk --no-cache del \
         build-base \

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.8.4"
+gem "jekyll", "~> 3.8.5"
 
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-feed", "~> 0.11.0"
   gem "jekyll-paginate-v2", "~> 2.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -14,7 +14,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.4)
+    jekyll (3.8.5)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -46,12 +46,12 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     rouge (3.3.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.6.0)
+    sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -61,8 +61,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 3.8.4)
-  jekyll-feed (~> 0.6)
+  jekyll (~> 3.8.5)
+  jekyll-feed (~> 0.11.0)
   jekyll-paginate-v2 (~> 2.0)
 
 BUNDLED WITH


### PR DESCRIPTION
Also bumped Jekyll while fiddling with Gemfile.