### PR TITLE
Add: support binary distribution via our new infrastructure

### DIFF
--- a/_download-meta/catcodec-releases.md
+++ b/_download-meta/catcodec-releases.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/catcodec
+folder_old_infrastructure: extra/catcodec
 ---

--- a/_download-meta/grfcodec-nightlies.md
+++ b/_download-meta/grfcodec-nightlies.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/grfcodec-trunk
+folder_old_infrastructure: extra/grfcodec-trunk
 ---

--- a/_download-meta/grfcodec-releases.md
+++ b/_download-meta/grfcodec-releases.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/grfcodec
+folder_old_infrastructure: extra/grfcodec
 ---

--- a/_download-meta/nforenum-releases.md
+++ b/_download-meta/nforenum-releases.md
@@ -1,5 +1,5 @@
 ---
-folder: extra/nforenum
+folder_old_infrastructure: extra/nforenum
 ---
 
 This package is deprecated. Please use [grfcodec](../grfcodec-releases/latest.html).

--- a/_download-meta/nosound-releases.md
+++ b/_download-meta/nosound-releases.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/nosound
+folder_old_infrastructure: extra/nosound
 ---

--- a/_download-meta/opengfx-releases.md
+++ b/_download-meta/opengfx-releases.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/opengfx
+folder_old_infrastructure: extra/opengfx
 ---

--- a/_download-meta/openmsx-releases.md
+++ b/_download-meta/openmsx-releases.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/openmsx
+folder_old_infrastructure: extra/openmsx
 ---

--- a/_download-meta/opensfx-releases.md
+++ b/_download-meta/opensfx-releases.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/opensfx
+folder_old_infrastructure: extra/opensfx
 ---

--- a/_download-meta/openttd-nightlies.md
+++ b/_download-meta/openttd-nightlies.md
@@ -1,10 +1,10 @@
 ---
-folder: nightlies/trunk
+folder_old_infrastructure: nightlies/trunk
 ---
 
 For OpenTTD you can use the original Transport Tycoon Deluxe data files (you need to own a Transport Tycoon Deluxe CD).
 There are also the free alternatives: [OpenGFX (graphics)](http://dev.openttdcoop.org/projects/opengfx), [OpenSFX (sound)](http://dev.openttdcoop.org/projects/opensfx), and [OpenMSX (music)](http://dev.openttdcoop.org/projects/openmsx).
 These can be installed automatically by the Windows and OS/2 installers.
-Please refer to the [readme](https://binaries.openttd.org/nightlies/trunk/@@version@@/readme.txt) for more information.
+Please refer to the [readme](https://openttd.ams3.cdn.digitaloceanspaces.com/openttd-nightlies/@@version@@/README.md) for more information.
 
 You can download the free alternatives here: [download OpenGFX](../opengfx-releases/latest.html), [download OpenSFX](../opensfx-releases/latest.html), and [download OpenMSX](../openmsx-releases/latest.html).

--- a/_download-meta/openttd-releases.md
+++ b/_download-meta/openttd-releases.md
@@ -1,5 +1,5 @@
 ---
-folder: releases
+folder_old_infrastructure: releases
 ---
 
 For OpenTTD you can use the original Transport Tycoon Deluxe data files (you need to own a Transport Tycoon Deluxe CD).

--- a/_download-meta/openttd-useful.md
+++ b/_download-meta/openttd-useful.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/openttd-useful
+folder_old_infrastructure: extra/openttd-useful
 ---

--- a/_download-meta/osie-releases.md
+++ b/_download-meta/osie-releases.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/osie
+folder_old_infrastructure: extra/osie
 ---

--- a/_download-meta/pngcodec-releases.md
+++ b/_download-meta/pngcodec-releases.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/pngcodec
+folder_old_infrastructure: extra/pngcodec
 ---

--- a/_download-meta/strgen-releases.md
+++ b/_download-meta/strgen-releases.md
@@ -1,3 +1,3 @@
 ---
-folder: extra/strgen
+folder_old_infrastructure: extra/strgen
 ---

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
                 {% if latest_stable.date < latest_testing.date %}
                 <h5><a href="{{ site.baseurl }}{{ latest_testing.url }}">Download testing ({{ latest_testing.version }})</a></h5>
                 {% endif %}
-                <h5><a href="{{ site.baseurl }}{{ latest_nightly.url }}">Download nightly ({{ latest_nightly.version }})</a></h5>
+                <h5><a href="{{ site.baseurl }}{{ latest_nightly.url }}">Download nightly ({{ latest_nightly.version | split: "-" | slice: 0 }})</a></h5>
             </div>
             <div id="header-logo">
                 <div id="openttd-logo">

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -17,6 +17,12 @@ js:
 {% assign version = page.version %}
 {% endunless %}
 
+{% if page.on_old_infrastructure %}
+{% assign folder = meta.folder_old_infrastructure %}
+{% else %}
+{% assign folder = raw_type %}
+{% endif %}
+
 {% unless meta.id %}
     {{ "No download-meta entry found for " | append: raw_type | raise_error }}
 {% endunless %}
@@ -40,7 +46,7 @@ js:
         <div class="content">
             <p>Latest release in {{ page.name }} is {{ version }}, released on {{ page.date | date: "%Y-%m-%d %H:%M" }} UTC.</p>
 
-            <div class="changelog">[ <a href="https://binaries.openttd.org/{{ meta.folder }}/{{ version }}/changelog.txt">Changelog</a> ]</div>
+            <div class="changelog">[ <a href="{{ page.host }}/{{ folder }}/{{ version }}/changelog.txt">Changelog</a> ]</div>
             <div id="download-combo">
                 <input type="hidden" id="download-combo-state" value="" />
                 <input type="hidden" id="download-base-name" value="{{ page.base }}" />
@@ -55,7 +61,7 @@ js:
                 {% endunless %}
 
                 <li id="{{ file.id }}">
-                    <div class="filename"><a href="https://binaries.openttd.org/{{ meta.folder }}/{{ version }}/{{ file.id }}">{{ description }}</a></div>
+                    <div class="filename"><a href="{{ page.host }}/{{ folder }}/{{ version }}/{{ file.id }}">{{ description }}</a></div>
                     <div class="filesize">[ {{ file.size | string_of_size }} ]</div>
                     <div class="checksums-dropdown" onclick="toggleChecksum(this, 'checksum-{{ file.id }}')">[ <a href="#" onclick="return false;">Checksums</a> ]</div>
                     <div class="checksums" id="checksum-{{ file.id }}">


### PR DESCRIPTION
Binaries are uploaded to a CDN. listing.txt and latest.txt help
navigate the CDN.

Currently both infrastructures are supported. We will slowly
migrate everything to the new infrastructure, once everything is
live and in working order.