### PR TITLE
Fix: use proxy.binaries instead of direct CDN URL

### DIFF
--- a/_download-meta/openttd-nightlies.md
+++ b/_download-meta/openttd-nightlies.md
@@ -5,6 +5,6 @@ folder_old_infrastructure: nightlies/trunk
 For OpenTTD you can use the original Transport Tycoon Deluxe data files (you need to own a Transport Tycoon Deluxe CD).
 There are also the free alternatives: [OpenGFX (graphics)](http://dev.openttdcoop.org/projects/opengfx), [OpenSFX (sound)](http://dev.openttdcoop.org/projects/opensfx), and [OpenMSX (music)](http://dev.openttdcoop.org/projects/openmsx).
 These can be installed automatically by the Windows and OS/2 installers.
-Please refer to the [readme](https://openttd.ams3.cdn.digitaloceanspaces.com/openttd-nightlies/@@version@@/README.md) for more information.
+Please refer to the [readme](https://proxy.binaries.openttd.org/openttd-nightlies/@@version@@/README.md) for more information.
 
 You can download the free alternatives here: [download OpenGFX](../opengfx-releases/latest.html), [download OpenSFX](../opensfx-releases/latest.html), and [download OpenMSX](../openmsx-releases/latest.html).

--- a/fetch-downloads.py
+++ b/fetch-downloads.py
@@ -192,7 +192,7 @@ async def main():
                 type,
                 type,
                 version,
-                "https://openttd.ams3.cdn.digitaloceanspaces.com",
+                "https://proxy.binaries.openttd.org",
                 latest=latest)
 
     await session.close()


### PR DESCRIPTION
The DigitalOcean CDN doesn't support IPv6.
proxy.binaries.openttd.org does, so redirect traffic via that
address. This is not optimal, but being reachable is more important
than being optimal.

Fixes #21 