### PR TITLE
Add: url for health probe, which always returns 200

### DIFF
--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -9,6 +9,11 @@ server {
     # The downloads folder has no index.html, so redirect it to the frontpage
     if ($request_uri ~ ^/downloads/$) { return 301 $scheme://$http_host/; }
 
+    location /healthz {
+        access_log off;
+        return 200;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html latest.html;


### PR DESCRIPTION
We cannot trust any URL to give a correct response, as we are not
in control of that data.