### PR TITLE
Fix: 'testing' and 'stable' were always the latest version

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,9 +20,9 @@
     </head>
     <body>
         <div id="header">
-            {% assign latest_stable = site.downloads | where_exp: "download", "download.id == '/downloads/openttd-releases/latest'" |  last %}
+            {% assign latest_stable = site.downloads | where_exp: "download", "download.id contains '/downloads/openttd-releases/'" | where_exp: "download", "download.name == 'stable'" | sort: "id" | last %}
             {% assign latest_testing = site.downloads | where_exp: "download", "download.id == '/downloads/openttd-releases/latest'" | last %}
-            {% assign latest_nightly = site.downloads | where_exp: "download", "download.id contains '/downloads/openttd-nightlies/latest'" | last %}
+            {% assign latest_nightly = site.downloads | where_exp: "download", "download.id == '/downloads/openttd-nightlies/latest'" | last %}
 
             <div id="header-left"></div>
             <div id="header-right"></div>

--- a/fetch-downloads.py
+++ b/fetch-downloads.py
@@ -149,15 +149,17 @@ async def write_to_collection(type, version, manifest):
 async def handle_version(folder, type, version, host, on_old_infrastructure="false", latest=None):
     print(f"Adding {type}/{version} to downloads collection ..")
     manifest = await fetch_manifest(folder, version, host, on_old_infrastructure=on_old_infrastructure)
+
+    # Insert the version into the header; otherwise we don't know
+    # what version this was on the downloads page.
+    manifest = manifest.split("\n")
+    manifest.insert(1, f"version: {version}")
+    manifest = "\n".join(manifest)
+
     await write_to_collection(type, version, manifest)
 
     # If this is the current version, also copy the content to "latest"
     if version == latest:
-        # Insert the version into the header; otherwise we don't know
-        # what version this was on the downloads page.
-        manifest = manifest.split("\n")
-        manifest.insert(1, f"version: {version}")
-        manifest = "\n".join(manifest)
         await write_to_collection(type, "latest", manifest)
 
 


### PR DESCRIPTION
This meant 'stable' could become '1.9.0-beta1', which is never
what we want.