### PR TITLE
Fix 7038a71: link to changelog was incorrectly pointing to the CDN directly

### DIFF
--- a/_posts/2019-02-25-1.9.0-beta3.md
+++ b/_posts/2019-02-25-1.9.0-beta3.md
@@ -8,8 +8,8 @@ OpenTTD 1.9.0-beta3 is now available, changes since beta2 include:
 * Option to adjust font size separately from GUI size
 * Increase maximum number of orders from 64000 to ~16.7m
 * Show performance of AI and GS in framerate window
-* News menu entry and shortcut for deleting all messages 
+* News menu entry and shortcut for deleting all messages
 * Multiple UI improvements
 * Multiple fixes
 
-Full [changelog](https://openttd.ams3.cdn.digitaloceanspaces.com/openttd-releases/1.9.0-beta3/changelog.txt) and [download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+Full [changelog](https://proxy.binaries.openttd.org/openttd-releases/1.9.0-beta3/changelog.txt) and [download](https://www.openttd.org/downloads/openttd-releases/testing.html)


### PR DESCRIPTION
The CDN is IPv4 only. The proxy.binaries URL routes traffic
correctly, depending if you are IPv4 or IPv6. Please avoid
public links to CDN directly.