### PR TITLE
Update: New bank details for donations

### DIFF
--- a/pages/donate.html
+++ b/pages/donate.html
@@ -16,6 +16,16 @@ permalink: /donate.html
             <p>If you would like to support OpenTTD, donations can be made in a number of ways:</p>
             <ul class="section-list">
                 <li>
+                    <div class="header">Bank transfer</div>
+                    <div class="content">A direct bank transfer is generally the cheapest way to donate, if you have a GBP, USD or EUR bank account. Please note that this may incur charges from your bank otherwise. You can use the following bank details to donate. Please note that the accounts listed below will only accept transfers from the countries specified.
+                        <ul>
+                            <li><b>GBP (United Kingdom)</b>: Account number <b>75798685</b>, sort code <b>23-14-70</b></li>
+                            <li><b>USD (United States)</b>: Please e-mail <a href="mailto:orudge@openttd.org">Owen Rudge</a> for details</li>
+                            <li><b>EUR (Eurozone)</b>: IBAN <b>DE84 7001 1110 6055 8745 20</b>, BIC <b>DEKTDE7GXXX</b></li>
+                        </ul>
+                        If you have any queries or wish to donate from another country, please contact <a href="mailto:orudge@openttd.org">Owen Rudge</a>.</div>
+                </li>
+                <li>
                     <div class="header">PayPal</div>
                     <div class="content">
                         <a href="https://www.paypal.com/">PayPal</a> is the most common and perhaps the easiest way to make a donation. You can specify an amount to donate, in any currency supported by PayPal, and if you don't have a PayPal account, you can pay by credit/debit card without signing up for an account. If you would like to donate in this way, please click one of the following links:
@@ -25,10 +35,6 @@ permalink: /donate.html
                             <li><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&amp;business=owen%40owenrudge%2enet&amp;item_name=OpenTTD&amp;no_shipping=0&amp;no_note=1&amp;tax=0&amp;currency_code=EUR&amp;bn=PP%2dDonationsBF&amp;charset=UTF%2d8">Donate in Euros (EUR)</a></li>
                         </ul>
                     </div>
-                </li>
-                <li>
-                    <div class="header">Bank transfer</div>
-                    <div class="content">A direct bank transfer is another possible method of donation. Please note that this may incur charges from your bank (the recipient bank account is in the United Kingdom). If you are interested in donating this way, please contact <a href="mailto:orudge@openttd.org">Owen Rudge</a>.</div>
                 </li>
                 <li>
                     <div class="header">Cheque</div>


### PR DESCRIPTION
Prioritise bank transfers over PayPal, and add new bank details (separate accounts for EUR and USD to save on currency conversion fees)