### PR TITLE
Fix: 'development environments' link was broken #75

### DIFF
--- a/pages/development.html
+++ b/pages/development.html
@@ -63,7 +63,7 @@ permalink: /development.html
                 <li><a href="http://www.libsdl.org/">sdl</a> to be able to draw on the screen (not needed on Windows and Mac OS X).</li>
                 <li><a href="http://icu-project.org/">icu</a> to be able to render bi-directional text (Arabic, Hebrew, etc.)</li>
             </ul>
-            <p>For further instructions on how to properly set up your system to build OpenTTD, take a look at our wiki page about <a href="https://wiki.openttd.org/Coding_Tools">development environments</a>.</p>
+            <p>For further instructions on how to properly set up your system to build OpenTTD, take a look at our wiki page about <a href="https://wiki.openttd.org/Development">development environments</a>.</p>
         </div>
     </div>
     <div class="section-header">


### PR DESCRIPTION
Swapped the link to a wiki page that isn't deleted.  Fixes #75 