### PR TITLE
Fix: Remove extra padding-top for download headers

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -113,12 +113,6 @@ h5, .h5 {
 	padding: 5px 12px 5px 45px;
 	text-align: left;
 }
-#download-fast-1 {
-	padding-top: 15px;
-}
-#download-fast-2 {
-	padding-top: 10px;
-}
 #download-fast-1 h5 a, #download-fast-2 h5 a, #download-fast-3 h5 a {
 	color: #CCCCCC;
 	font-size: 11px;

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -110,7 +110,7 @@ h5, .h5 {
 	float: left;
 	line-height: 12px;
 	margin: 22px 0px 0px 10px;
-	padding: 5px 12px 5px 45px;
+	padding: 9px 12px 9px 45px;
 	text-align: left;
 }
 #download-fast-1 h5 a, #download-fast-2 h5 a, #download-fast-3 h5 a {


### PR DESCRIPTION
Now looks like this:

![](https://i.imgur.com/9oSaiSt.png)