### PR TITLE
Discussion basis for rework of the general HTML structure and the CSS rules

### DIFF
--- a/_includes/post_macro.html
+++ b/_includes/post_macro.html
@@ -1,17 +1,9 @@
-<div class="section-item">
-    <div class="title">
-        <h3>
-            <a href="{{ base }}{{ post.url }}">{{ post.title }}</a>
-        </h3>
-    </div>
-    <div class="date">
-        <h5>{{ post.date | date: "%Y-%m-%d" }}</h5>
-    </div>
-    <div class="user">
-        <h5>
-            Posted by {{ post.author }}
-        </h5>
-    </div>
+<article class="section-item">
+    <header>
+        <h3><a href="{{ base }}{{ post.url }}">{{ post.title }}</a></h3>
+        <div class="date"><time>{{ post.date | date: "%Y-%m-%d" }}</time></div>
+        <p class="user">Posted by {{ post.author }}</p>
+    </header>
     <div class="content">
         {% if include.excerpt %}
         {{ post.excerpt }}
@@ -23,4 +15,4 @@
         {{ post.content }}
         {% endif %}
     </div>
-</div>
+</article>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
         <title>OpenTTD{% if layout.section_title != nil %} | {{layout.section_title}}{% endif %} | {{ page.title }}</title>
     </head>
     <body>
-        <div id="header">
+        <header id="header">
             {% assign latest_stable = site.downloads | where_exp: "download", "download.id == '/downloads/openttd-releases/latest'" | last %}
             {% assign latest_testing = site.downloads | where_exp: "download", "download.id == '/downloads/openttd-releases/testing'" | last %}
             {% assign latest_nightly = site.downloads | where_exp: "download", "download.id == '/downloads/openttd-nightlies/latest'" | last %}
@@ -48,7 +48,7 @@
                     <div id="openttd-logo-text"><a href="{{ site.baseurl }}"><img src="{{ site.staticurl }}/img/layout/openttd-logo.png" alt="OpenTTD" /></a></div>
                 </div>
             </div>
-        </div>
+        </header>
         <div id="navigation">
             <div id="navigation-left"></div>
             <div id="navigation-right"></div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -56,9 +56,9 @@
                 <li><a{% if page.active_nav != 'donate' %} href="{{ site.baseurl }}/donate.html"{% endif %}>Donate</a></li>
             </ul>
         </nav>
-        <div id="content-main">
+        <main id="content-main">
             {{ content }}
-            <hr id="hr-clear" />
+        </main>
             <div id="content-bottom">
                 <div id="content-bottom-links">
                     <a href="{{ site.baseurl }}/policy.html">Privacy Policy</a> |

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -59,16 +59,15 @@
         <main id="content-main">
             {{ content }}
         </main>
+        <footer>
             <div id="content-bottom">
-                <div id="content-bottom-links">
-                    <a href="{{ site.baseurl }}/policy.html">Privacy Policy</a> |
-                    <a href="https://account.openttd.org/en/login">Login</a> |
-                    <a href="{{ site.baseurl }}/contact.html">Contact</a>
-                </div>
-                <div id="content-bottom-copyright">
-                    Copyright &copy; 2005-{{ site.time | date: '%Y' }} OpenTTD Team
-                </div>
+                <ul>
+                    <li><a href="{{ site.baseurl }}/policy.html">Privacy Policy</a></li>
+                    <li><a href="https://account.openttd.org/en/login">Login</a></li>
+                    <li><a href="{{ site.baseurl }}/contact.html">Contact</a></li>
+                </ul>
+                <p id="content-bottom-copyright">Copyright &copy; 2005-{{ site.time | date: '%Y' }} OpenTTD Team</p>
             </div>
-        </div>
+        </footer>
     </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,9 +29,6 @@
             {% assign nightly_version = latest_nightly.version | split: "-" | slice: 0 %}
             {% endif %}
 
-            <div id="header-left"></div>
-            <div id="header-right"></div>
-
             {% if latest_stable.date < latest_testing.date %}
             <div id="download-fast-3">
             {% else %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
         <script type="text/javascript" src="{{ site.staticurl }}/js/{{ filename }}"></script>
         {% endfor %}
         {% feed_meta %}
-        <title>OpenTTD {% if layout.section_title != nil %}| {{layout.section_title}}{% endif %} | {{ page.title }}</title>
+        <title>OpenTTD{% if layout.section_title != nil %} | {{layout.section_title}}{% endif %} | {{ page.title }}</title>
     </head>
     <body>
         <div id="header">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,34 +42,20 @@
                 </div>
             </div>
         </header>
-        <div id="navigation">
-            <div id="navigation-left"></div>
-            <div id="navigation-right"></div>
-            <ul id="navigation-bar">
-                <li class="{% if page.active_nav == 'home' %}selected{% endif %}">
-                    <a href="{{ site.baseurl }}/">Home</a>
-                </li>
-                <li class="{% if page.active_nav == 'about' %}selected{% endif %}">
-                    <a href="{{ site.baseurl }}/about.html">About</a>
-                </li>
+        <nav id="navigation-bar">
+            <ul>
+                <li><a{% if page.active_nav != 'home' %} href="{{ site.baseurl }}/"{% endif %}>Home</a></li>
+                <li><a{% if page.active_nav != 'about' %} href="{{ site.baseurl }}/about.html"{% endif %}>About</a></li>
                 <li><a href="https://wiki.openttd.org/">Manual</a></li>
-                <li class="{% if page.active_nav == 'screenshots' or layout.active_nav == 'screenshots' %}selected{% endif %}">
-                    <a href="{{ site.baseurl }}/screenshots.html">Screenshots</a>
-                </li>
+                <li><a{% if page.active_nav != 'screenshots' or layout.active_nav == 'screenshots' %} href="{{ site.baseurl }}/screenshots.html"{% endif %}>Screenshots</a></li>
                 <li><a href="https://servers.openttd.org">Servers</a></li>
-                <li class="{% if page.active_nav == 'development' %}selected{% endif %}">
-                    <a href="{{ site.baseurl }}/development.html">Development</a>
-                </li>
+                <li><a{% if page.active_nav != 'development' %} href="{{ site.baseurl }}/development.html"{% endif %}>Development</a></li>
                 <li><a href="https://forum.openttd.org/">Forum</a></li>
                 <li><a href="https://wiki.openttd.org/Community">Community</a></li>
-                <li class="{% if page.active_nav == 'contact' %}selected{% endif %}">
-                    <a href="{{ site.baseurl }}/contact.html">Contact</a>
-                </li>
-                <li class="{% if page.active_nav == 'donate' %}selected{% endif %}">
-                    <a href="{{ site.baseurl }}/donate.html">Donate</a>
-                </li>
+                <li><a{% if page.active_nav != 'contact' %} href="{{ site.baseurl }}/contact.html"{% endif %}>Contact</a></li>
+                <li><a{% if page.active_nav != 'donate' %} href="{{ site.baseurl }}/donate.html"{% endif %}>Donate</a></li>
             </ul>
-        </div>
+        </nav>
         <div id="content-main">
             {{ content }}
             <hr id="hr-clear" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,6 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="Description" content="An open source simulator based on the classic game Transport Tycoon Deluxe. It attempts to mimic the original game as closely as possible while extending it with new features." />
         <meta name="Keywords" content="Transport,Tycoon,Deluxe,TTDLX,TTD,OpenTTD,OTTD" />
         <link rel="icon" href="{{ site.staticurl }}/favicon.ico" type="image/icon" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,17 +29,13 @@
             {% assign nightly_version = latest_nightly.version | split: "-" | slice: 0 %}
             {% endif %}
 
-            {% if latest_stable.date < latest_testing.date %}
-            <div id="download-fast-3">
-            {% else %}
-            <div id="download-fast-2">
-            {% endif %}
-                <h5><a href="{{ site.baseurl }}{{ latest_stable.url }}">Download stable ({{ latest_stable.version }})</a></h5>
+            <ul id="header-download">
+                <li><a href="{{ site.baseurl }}{{ latest_stable.url }}">Download stable ({{ latest_stable.version }})</a></li>
                 {% if latest_stable.date < latest_testing.date %}
-                <h5><a href="{{ site.baseurl }}{{ latest_testing.url }}">Download testing ({{ latest_testing.version }})</a></h5>
+                <li><a href="{{ site.baseurl }}{{ latest_testing.url }}">Download testing ({{ latest_testing.version }})</a></li>
                 {% endif %}
-                <h5><a href="{{ site.baseurl }}{{ latest_nightly.url }}">Download nightly ({{ nightly_version }})</a></h5>
-            </div>
+                <li><a href="{{ site.baseurl }}{{ latest_nightly.url }}">Download nightly ({{ nightly_version }})</a></li>
+            </ul>
             <div id="header-logo">
                 <div id="openttd-logo">
                     <div id="openttd-logo-text"><a href="{{ site.baseurl }}"><img src="{{ site.staticurl }}/img/layout/openttd-logo.png" alt="OpenTTD" /></a></div>


### PR DESCRIPTION
This is a draft for a new HTML and CSS structure without (in a first step) major changes to the look and behaviour of the OpenTTD website. It should not step into competition to the draft of @LordAro in PR #80. Instead it should be a discussion basis to come to a favourable result in the end, that in itself is a proper basis for a later responsive redesing of the website.

This draft is not complete and the changes are separated in smaller portions.

Differences to the draft of @LordAro:

- The template for the blog entries declares a blog entry as an article instead a section, provides a header (HTML element) for the entry that keeps the articles heading and provides the meta data (date and the authors name) in block elements but not in further headers (these meta data are no headings).
- The main template follows in general to the changes in #80 but …
    - … stores the download links in the header in a list, …
    - … replaces the class definitions for the current page in the main navigation by a remove of the href-attribute of the link (can be reached with CSS rule `a:not([href])`) …
    - … and mark-up the page footer as a link list and a paragraph for the copyright note

Until now I have no draft for pages/index.html and for the CSS. If you want to have it for comparision of ideas, please ask for it. 