### PR TITLE
Change: HTML5-elements and corresponding CSS-rules for the blog article template

### DIFF
--- a/_includes/post_macro.html
+++ b/_includes/post_macro.html
@@ -1,26 +1,20 @@
-<div class="section-item">
-    <div class="title">
-        <h3>
-            <a href="{{ base }}{{ post.url }}">{{ post.title }}</a>
-        </h3>
-    </div>
-    <div class="date">
-        <h5>{{ post.date | date: "%Y-%m-%d" }}</h5>
-    </div>
-    <div class="user">
-        <h5>
-            Posted by {{ post.author }}
-        </h5>
-    </div>
+<article>
+    <header>
+        <h3><a href="{{ base }}{{ post.url }}">{{ post.title }}</a></h3>
+        <p class="blog-item-metadata">
+            <time>{{ post.date | date: "%Y-%m-%d" }}</time>
+            <span class="user">Posted by {{ post.author }}</span>
+        </p>
+    </header>
     <div class="content">
         {% if include.excerpt %}
         {{ post.excerpt }}
 
         {% if post.excerpt != post.content %}
-            <a href="{{ site.baseurl }}{{ post.url }}">Read more</a>
+            <p><a href="{{ site.baseurl }}{{ post.url }}">Read more</a></p>
         {% endif %}
         {% else %}
         {{ post.content }}
         {% endif %}
     </div>
-</div>
+</article>

--- a/static/css/page.css
+++ b/static/css/page.css
@@ -59,6 +59,33 @@
 	text-align: justify;
 }
 
+article {
+	margin-top: 10px;
+}
+article > header {
+	border-bottom: 1px dotted #d8d8d8;
+}
+article > header h3, article > header h3 a {
+	color: #000;
+	font-size: 18px;
+	font-weight: bold;
+	text-decoration: none;
+}
+article > header h3 a:focus, article > header h3 a:hover {
+	color: #DD6000;
+	text-decoration: underline;
+}
+article > header p {
+	margin: 5px 0;
+	color: #282828;
+}
+article > .content {
+	border-bottom: 1px solid #d8d8d8;
+	font-size: 14px;
+	padding: 5px 15px 30px 15px;
+	text-align: justify;
+}
+
 .section-item hr {
 	width: 500px;
 }

--- a/static/css/page.css
+++ b/static/css/page.css
@@ -64,6 +64,13 @@ article {
 }
 article > header {
 	border-bottom: 1px dotted #d8d8d8;
+	padding: 0 0 5px 0;
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+}
+article > header h3 {
+	flex: 1 1 auto;
 }
 article > header h3, article > header h3 a {
 	color: #000;
@@ -76,8 +83,13 @@ article > header h3 a:focus, article > header h3 a:hover {
 	text-decoration: underline;
 }
 article > header p {
-	margin: 5px 0;
+	margin: 0;
 	color: #282828;
+	flex: 0 0 11em;
+	text-align: right;
+}
+article > header p > * {
+	display: block;
 }
 article > .content {
 	border-bottom: 1px solid #d8d8d8;


### PR DESCRIPTION
As proposed in #82 the blog article template was reorganised as `<article>` with a `<header>` that contains the heading and the meta data (time and authors name) and the `div.content`.

**Optical changes**

- the blog articles meta data got their own text line below the articles heading; this could be reset to right aligned after the rework of the whole site with a mobile aware and responsive design (stays below heading on narrow viewports and moves to the right side on wide viewports)
- the `<header>` got a dotted `border-bottom` as separator from the articles content
- the border of the header and also the border of the content got an a bit darker colour (`#d8d8d8` instead `#eee`)

**Further change under the hood**

- the read-more-link got an own paragraph

I kept the rules for  `.section-item` because they are still in use on several places (see directory `pages`). These pages will get a rework later.