### PR TITLE
Change: Don't push push notifications to IRC

### DIFF
--- a/.dorpsgek.yml
+++ b/.dorpsgek.yml
@@ -1,13 +1,14 @@
 notifications:
+  global:
+    irc:
+      - openttd
+      - openttd.notice
+
   push:
-    irc:
-      - openttd
-      - openttd.notice
+    only:
+    - master
+    only-by:
+    - DorpsGek
+  commit-comment:
   pull-request:
-    irc:
-      - openttd
-      - openttd.notice
   issue:
-    irc:
-      - openttd
-      - openttd.notice


### PR DESCRIPTION
Mirror OTTD's dorpsgek.yml file. Not that I'm sure why DorpsGek would manage to commit to the repo...

(Sorry about the local branch creation, forced by GH UI...)