### PR TITLE
Fix typo/inconsistency in October monthly dev post

### DIFF
--- a/_posts/2019-10-26-monthly-dev-post.md
+++ b/_posts/2019-10-26-monthly-dev-post.md
@@ -1,5 +1,5 @@
 ---
-title: Monthly Dev Post October 2019
+title: Monthly Dev Post of October 2019
 author: People
 ---
 


### PR DESCRIPTION
All the other monthly dev posts say "Monthly Dev Post of (MMMM) (YYYY)", but this didn't have the "of".