### PR TITLE
Fix: update bundler version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apk --no-cache add \
     && gem update --system \
     && gem install http_parser.rb -v 0.6.0 -- --use-system-libraries \
     && gem install safe_yaml -v 1.0.4 -- --use-system-libraries \
+    && bundle update --bundler \
     && bundle install \
     && apk --no-cache del \
         build-base \


### PR DESCRIPTION
Docker build is broken since december 16th (rubygems updated from 3.0.6 to 3.1.1, including an update for bundler from 1.17.3 to 2.1.0).
I don't know if it's the right fix, but it works :)
Other option is to install older bundler.