### PR TITLE
Various of fixes in preparation of running this Docker on AWS

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,74 @@
+name: Deployment
+
+on:
+  deployment:
+
+jobs:
+  deploy_to_aws:
+    name: Deploy to AWS
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Deployment in progress
+      uses: actions/github-script@0.3.0
+      with:
+        github-token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        previews: flash,ant-man
+        script: |
+          github.repos.createDeploymentStatus({
+            owner: context.payload.repository.owner.login,
+            repo: context.payload.repository.name,
+            deployment_id: context.payload.deployment.id,
+            state: "in_progress",
+            description: "Deployment of ${{ github.event.deployment.payload.version }} to ${{ github.event.deployment.environment }} started",
+          })
+
+    - name: Deploy on AWS
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      run: |
+        if [ "${{ github.event.deployment.environment }}" = "production" ]; then
+          STACK="Live-Production-Website"
+          PARAMETER="/Live/Version/Production/Website"
+        else
+          STACK="Live-Staging-Website"
+          PARAMETER="/Live/Version/Staging/Website"
+        fi
+
+        aws ssm put-parameter --region ${AWS_REGION} --name ${PARAMETER} --type String --overwrite --value "@${{ github.event.deployment.payload.tag }}" --description "${{ github.event.deployment.payload.version }} on ${{ github.event.deployment.payload.date }}"
+        aws cloudformation update-stack --region ${AWS_REGION} --stack-name ${STACK} --use-previous-template
+
+        echo "Waiting for deployment to finish .. (normally ~3 minutes)"
+        aws cloudformation wait stack-update-complete --region ${AWS_REGION} --stack-name ${STACK}
+
+    - if: success()
+      name: Deployment successful
+      uses: actions/github-script@0.3.0
+      with:
+        github-token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        previews: flash,ant-man
+        script: |
+          github.repos.createDeploymentStatus({
+            owner: context.payload.repository.owner.login,
+            repo: context.payload.repository.name,
+            deployment_id: context.payload.deployment.id,
+            state: "success",
+            description: "Successfully deployed ${{ github.event.deployment.payload.version }} on ${{ github.event.deployment.environment }}",
+            environment_url: "https://www.staging.openttd.org/"
+          })
+
+    - if: failure() || cancelled()
+      name: Deployment failed
+      uses: actions/github-script@0.3.0
+      with:
+        github-token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        previews: flash,ant-man
+        script: |
+          github.repos.createDeploymentStatus({
+            owner: context.payload.repository.owner.login,
+            repo: context.payload.repository.name,
+            deployment_id: context.payload.deployment.id,
+            state: "failure",
+          })

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,139 @@
+name: Publish image
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - '*'
+  repository_dispatch:
+    types:
+    - publish_latest_tag
+    - publish_master
+
+jobs:
+  publish_image:
+    name: Publish image
+    runs-on: ubuntu-latest
+
+    steps:
+    - if: github.event_name == 'repository_dispatch'
+      name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - if: github.event_name != 'repository_dispatch'
+      name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Checkout tags and submodules
+      shell: bash
+      run: |
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+        AUTH_HEADER="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=${AUTH_HEADER}" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+
+    - name: Set variables
+      id: vars
+      run: |
+        GITHUB_REPOSITORY_LC=$(echo "${GITHUB_REPOSITORY}" | tr [A-Z] [a-z])
+        echo "::set-output name=name::${GITHUB_REPOSITORY_LC}"
+        echo "Name: ${GITHUB_REPOSITORY_LC}"
+
+        VERSION=$(git describe --tags)
+        echo "::set-output name=version::${VERSION}"
+        echo "Version: ${VERSION}"
+
+        DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        echo "::set-output name=date::${DATE}"
+        echo "Date: ${DATE}"
+
+        if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+          if [ "${{ github.event.action }}" = "publish_latest_tag" ]; then
+            REF="refs/tags/$(git describe $(git rev-list --tags --max-count=1) --tags)"
+
+            # As we checkout out "refs/heads/master" earlier, we have to
+            # switch to the tag now.
+            git checkout ${REF}
+          else
+            REF="refs/heads/master"
+          fi
+        else
+          REF=${GITHUB_REF}
+        fi
+        echo "::set-output name=ref::${REF}"
+        echo "Ref: ${REF}"
+
+        if [ "${REF}" = "refs/heads/master" ]; then
+          ENVIRONMENT="staging"
+          TAG="development"
+          TAGS="dev"
+        else
+          ENVIRONMENT="production"
+          VERSION_MAJOR=$(echo ${VERSION} | sed -r 's/([0-9]+).*/\1/')
+          VERSION_MAJOR_MINOR=$(echo ${VERSION} | sed -r 's/([0-9]+).([0-9]+).*/\1.\2/')
+
+          TAG="${VERSION}"
+          TAGS="${VERSION_MAJOR} ${VERSION_MAJOR_MINOR}"
+        fi
+        echo "::set-output name=tag::${TAG}"
+        echo "::set-output name=tags::${TAGS}"
+        echo "::set-output name=environment::${ENVIRONMENT}"
+        echo "Tags: ${TAG} ${TAGS}"
+        echo "Environment: ${ENVIRONMENT}"
+
+        if [ -z "${{ secrets.DOCKER_USERNAME }}" ]; then
+          DRYRUN="true"
+        else
+          DRYRUN="false"
+        fi
+        echo "::set-output name=dryrun::${DRYRUN}"
+        echo "Dry run: ${DRYRUN}"
+
+    - name: Build
+      run: |
+        docker build -t \
+          ${{ steps.vars.outputs.name }}:${{ steps.vars.outputs.tag }} \
+          --build-arg BUILD_DATE=${{ steps.vars.outputs.date }} \
+          --build-arg BUILD_VERSION=${{ steps.vars.outputs.version }} \
+          .
+
+        # If this tag has multiple tags, publish them too
+        for tag in ${{ steps.vars.outputs.tags }}; do
+          docker tag ${{ steps.vars.outputs.name }}:${{ steps.vars.outputs.tag }} \
+            ${{ steps.vars.outputs.name }}:${tag}
+        done
+
+    - if: steps.vars.outputs.dryrun == 'false'
+      name: Publish
+      id: publish
+      run: |
+        echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        docker push ${{ steps.vars.outputs.name }}
+
+        DOCKER_TAG=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ steps.vars.outputs.name }}:${{ steps.vars.outputs.tag }} | cut -d@ -f2)
+        echo "::set-output name=docker_tag::${DOCKER_TAG}"
+        echo "Docker tag: ${DOCKER_TAG}"
+
+    - if: steps.vars.outputs.dryrun == 'false'
+      name: Trigger deployment
+      uses: actions/github-script@0.3.0
+      with:
+        github-token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        previews: ant-man
+        script: |
+          github.repos.createDeployment({
+            owner: context.payload.repository.owner.login,
+            repo: context.payload.repository.name,
+            ref: "${{ steps.vars.outputs.ref }}",
+            auto_merge: false,
+            environment: "${{ steps.vars.outputs.environment }}",
+            required_contexts: [],
+            description: "${{ steps.vars.outputs.version }} on ${{ steps.vars.outputs.date }}",
+            payload: { tag: "${{ steps.publish.outputs.docker_tag }}", version: "${{ steps.vars.outputs.version }}", date: "${{ steps.vars.outputs.date }}" }
+          })

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,23 @@
+name: Testing
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        AUTH_HEADER="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=${AUTH_HEADER}" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+    - name: Build
+      run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,5 @@ RUN mkdir /html \
 # Copy the HTML and serve it via nginx
 FROM nginx:alpine
 COPY --from=html /html/ /usr/share/nginx/html/
+RUN sed -i 's/access_log/# access_log/g' /etc/nginx/nginx.conf
 COPY nginx.default.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,15 @@ RUN mkdir /html \
 
 # Copy the HTML and serve it via nginx
 FROM nginx:alpine
+
+ARG BUILD_DATE=""
+ARG BUILD_VERSION="dev"
+
+LABEL maintainer="truebrain@openttd.org"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=${BUILD_DATE}
+LABEL org.label-schema.version=${BUILD_VERSION}
+
 COPY --from=html /html/ /usr/share/nginx/html/
 RUN sed -i 's/access_log/# access_log/g' /etc/nginx/nginx.conf
 COPY nginx.default.conf /etc/nginx/conf.d/default.conf

--- a/fetch-downloads.py
+++ b/fetch-downloads.py
@@ -53,7 +53,7 @@ async def get_old_download_folders():
 
     folders = {}
     for version in versions:
-        (version, date, folder) = version.split('\t', 2)
+        (version, date, folder) = version.split("\t", 2)
 
         # Do not process custom entries
         if folder.startswith("custom/"):
@@ -92,20 +92,20 @@ async def get_old_versions_of_folder(folder):
     listing = await download(f"https://binaries.openttd.org/{folder}/index.xml")
     listing = xmltodict.parse(listing.decode())
 
-    entries = listing['params']['param']['value']['struct']['member']
+    entries = listing["params"]["param"]["value"]["struct"]["member"]
     if not isinstance(entries, list):
         entries = [entries]
 
     versions = []
     for entry in entries:
         # Check if this is a directory
-        for value in entry['value']['struct']['member']:
-            if value['name'] == 'type' and value['value']['string'] == 'directory':
+        for value in entry["value"]["struct"]["member"]:
+            if value["name"] == "type" and value["value"]["string"] == "directory":
                 break
         else:
             continue
 
-        versions.append(entry['name'])
+        versions.append(entry["name"])
 
     return versions
 

--- a/fetch-downloads.py
+++ b/fetch-downloads.py
@@ -14,6 +14,7 @@ import os
 import xmltodict
 
 from collections import defaultdict
+from itertools import islice
 
 session = None
 
@@ -28,6 +29,14 @@ types = {
     "openttd-nightlies": "flatten",
     "openttd-releases": "stable-testing",
     "openttd-pullrequests": "name",
+}
+
+# If set, this category is limited to these amount of entries to generate HTML
+# pages for. This is mostly done because nightlies for example are stored till
+# the end of times, but generating HTML for every one of them is not useful.
+# People that want a very old nightly can browse the archives directly.
+limits = {
+    "openttd-nightlies": 14,
 }
 
 
@@ -171,9 +180,8 @@ async def main():
         os.makedirs(f"_downloads/{type}", exist_ok=True)
 
         versions = await get_old_versions_of_folder(folder)
-        # For the nightlies, only generate the first 90; the real list is 4000+
-        if type == "openttd-nightlies":
-            versions = versions[:90]
+        if type in limits:
+            versions = versions[:limits[type]]
 
         for version in versions:
             await handle_version(
@@ -190,8 +198,10 @@ async def main():
         latest_grouped = defaultdict(lambda: ["", ""])
         versions = await get_listing(type)
 
+        limit = limits.get(type)
+
         # Regroup the versions based on the method
-        for version, data in versions.items():
+        for version, data in islice(versions.items(), 0, limit):
             (date, name) = data
 
             if method == "flatten":

--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -1,3 +1,14 @@
+# Don't log 2XX and 3XX to spot problems quickly.
+# In the way this Docker is used in production, there is always a
+# webserver in front of it, logging everything. By minimizing what this
+# Docker is logging, we can easier see what is going wrong.
+map $status $loggable {
+    ~^[23]  0;
+    default 1;
+}
+
+access_log /var/log/nginx/access.log main if=$loggable;
+
 server {
     listen       80;
     server_name  localhost;


### PR DESCRIPTION
This is still a WIP. Missing:

- [x] Actions to test the repository
- [x] Actions to publish the repository (for master and tags)
- [x] Way to rebuild and publish an image
- [x] Deployment to AWS when a new image is created

(yes, this deprecates the use of Azure Pipelines)

I am going to change how tags are created on the images. The master branch will have the tag `dev` (and `development`), and it will overwrite this tag. The tags will have the tag (wit for example `1.1.18`): `1`, `1.1`, `1.1.18`, and here too it will overwrite these tags when rebuild/published. This means tags will no longer contain the date of when they were published. This will now be inside the docker image as a `LABEL`. See [here](https://hub.docker.com/r/openttd/website/tags?page=1&ordering=last_updated) to understand why the current system is not working :)

This means that production needs to fetch the latest tag, which can be a bit unclear. So, instead, we are going to deploy based on the `sha256` tag. The downside is that in the cluster it will be difficult to see which version is running exactly. The deployment page on GitHub hopefully will help with that.

Rebuilding can be done via `repository_dispatch`. This is a simple API call, and can do both master as tags.
