### PR TITLE
Remove width from body

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -5,7 +5,6 @@ html {
 	font-size: 12px;
 }
 body {
-	width: 785px;
 	margin: auto auto;
 }
 select {


### PR DESCRIPTION
It caused non-centered header and content blocks because they have own different fixed width.