### PR TITLE
Fix: use a sha instead of 'refs/heads/master' as ref for deployments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,10 @@ jobs:
         echo "::set-output name=ref::${REF}"
         echo "Ref: ${REF}"
 
+        SHA="$(git rev-parse --verify ${REF})"
+        echo "::set-output name=sha::${SHA}"
+        echo "Sha: ${SHA}"
+
         if [ "${REF}" = "refs/heads/master" ]; then
           ENVIRONMENT="staging"
           TAG="development"
@@ -130,7 +134,7 @@ jobs:
           github.repos.createDeployment({
             owner: context.payload.repository.owner.login,
             repo: context.payload.repository.name,
-            ref: "${{ steps.vars.outputs.ref }}",
+            ref: "${{ steps.vars.outputs.sha }}",
             auto_merge: false,
             environment: "${{ steps.vars.outputs.environment }}",
             required_contexts: [],


### PR DESCRIPTION
When merging a second pull-request while the first has not created
a deployment yet, the 'refs/heads/master' resolves to the wrong
sha-hash, showing the wrong commit being deployed (it deploys the
commit of the first, while showing it did the one of the last).