### PR TITLE
Fix: correct the width of main and footer

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,3 +1,6 @@
+*, ::before, ::after {
+	box-sizing: border-box;
+}
 html {
 	background: #ab9c7d;
 	color: black;
@@ -48,10 +51,13 @@ h5, .h5 {
 	-o-text-overflow: ellipsis;
 }
 
+body > * {
+	width: 800px;
+}
+
 body > header {
 	height: 90px;
 	margin: 0px auto;
-	width: 800px;
 	box-shadow: 0px 0px 5px #000000;
 	/* Stripes! */
 	background-image: linear-gradient(0deg, #323536 50%, #3c3e40 50%, #3c3e40 100%);
@@ -137,7 +143,6 @@ body > nav {
 	margin: 0px auto;
 	min-height: 32px;
 	overflow: hidden;
-	width: 800px;
 }
 #navigation-bar {
 	display: flex;
@@ -171,7 +176,6 @@ body > nav {
 main {
 	background-color: white;
 	margin: 12px auto;
-	width: 776px;
 	padding: 7px;
 	border-radius: 5px;
 	box-shadow: 0 0 3px 3px rgba(0, 0, 0, 0.11);
@@ -179,7 +183,6 @@ main {
 body > footer {
 	background-color: white;
 	margin: 0 auto 36px auto;
-	width: 776px;
 	padding: 7px 7px 6px 7px;
 	overflow: hidden;
 	border-radius: 5px;


### PR DESCRIPTION
The widths of the elements `main` and `footer` was broken (narrower than `header` and `nav`) because the width was only `776px` instead the `800px` of `header` and `nav` and in contrast to `header` and `nav` `main` and `footer` have a padding for their content which is part of the width calculation.

So the `main` and `footer` boxes had (as first issue) not the same width as `header` and `nav` and had (as second issue) a resulting width of `814px`when the rule for the box width said `width: 800px;` because the `7px` for `padding-left` and `padding-right` got added to the `800px`of the width-rule. 

The correction was done with changing the box model to border-box (which includes paddings and border-widths in the width calculation for the element). Additionally the width rule for the direct childs of body was moved to a descendent selector for all these elements.

**Attention** The descendent selector would select also *every **direct** child* of `body` that will *possibly introduced in the future*.