### PR TITLE
Make the website better navigable with keyboard

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -16,6 +16,9 @@ img {
 a {
 	color: #DD6000;
 }
+a:focus, a:hover {
+	color: #BB4000;
+}
 hr {
 	background: url("../img/layout/hr.png") repeat-x;
 	border: none;

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -73,7 +73,7 @@ body > header {
 	font-size: 11px;
 	text-decoration: none;
 }
-#download-fast h5 a:hover {
+#download-fast h5 a:focus, #download-fast h5 a:hover {
 	color: #999999;
 }
 
@@ -157,7 +157,7 @@ body > nav {
 	text-decoration: none;
 	text-align: center;
 }
-#navigation-bar li a:hover {
+#navigation-bar li a:focus, #navigation-bar li a:hover {
 	background: linear-gradient(#C4C4C4, #A5A5A5);
 	color: #444444;
 }

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -60,7 +60,7 @@
 	padding-top: 5px;
 	text-decoration: none;
 }
-#banner-links ul li a:hover {
+#banner-links ul li a:focus, #banner-links ul li a:hover {
 	color: #999999;
 }
 #banner-links .h3 {


### PR DESCRIPTION
Until now the CSS lacks rules for the pseudo class `:focus` for links. Because of that a keyboard user, who steps through the links, sees – in the best case – only the dotted outline. I added the `* a:focus` selectors where I found a matching selector for `* a:hover`. Now one, using the keyboard, sees the same formats as another one, using the mouse (cursor).

Additionally I added the general selector `a:focus, a:hover` for all links in text sections that got no formats from elsewhere. That way one can remark the focussed or hovered link by the dotted outline *and* the changing text colour.