### PR TITLE
Padding corrections as consequences of #130

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -29,7 +29,6 @@ js:
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Download</h3>
     </div>
     <div class="section-item">
@@ -39,7 +38,6 @@ js:
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Download {{ page.name }}</h3>
     </div>
     <div class="section-item">
@@ -78,7 +76,6 @@ js:
     </div>
     {% if page.dev_files %}
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Developer Files</h3>
     </div>
     <div class="section-item">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,6 @@ section_title: News
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Archived News</h3>
     </div>
     {% assign post = page %}

--- a/_layouts/screenshot.html
+++ b/_layouts/screenshot.html
@@ -6,7 +6,6 @@ section_title: Screenshots
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>OpenTTD screenshot</h3>
     </div>
     <div class="section-item">

--- a/pages/404.html
+++ b/pages/404.html
@@ -6,7 +6,6 @@ permalink: /404.html
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>404 - Page Not Found</h3>
     </div>
     <div class="section-item">

--- a/pages/50x.html
+++ b/pages/50x.html
@@ -5,7 +5,6 @@ permalink: /50x.html
 ---
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>500 - Internal Server Error</h3>
     </div>
     <div class="section-item">

--- a/pages/about.html
+++ b/pages/about.html
@@ -7,7 +7,6 @@ permalink: /about.html
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>About</h3>
     </div>
     <div class="section-item">
@@ -17,7 +16,6 @@ permalink: /about.html
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Features</h3>
     </div>
     <div class="section-item">
@@ -84,7 +82,6 @@ permalink: /about.html
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Supported operating systems</h3>
     </div>
     <div class="section-item">

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -7,7 +7,6 @@ permalink: /contact.html
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Contact Information</h3>
     </div>
     <div class="section-item">
@@ -39,7 +38,6 @@ permalink: /contact.html
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>IRC</h3>
     </div>
     <div class="section-item">
@@ -48,7 +46,6 @@ permalink: /contact.html
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Mirrors</h3>
     </div>
     <div class="section-item">

--- a/pages/development.html
+++ b/pages/development.html
@@ -7,7 +7,6 @@ permalink: /development.html
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Translating</h3>
     </div>
     <div class="section-item">
@@ -17,7 +16,6 @@ permalink: /development.html
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>What to do When You Find a Bug</h3>
     </div>
     <div class="section-item">
@@ -33,7 +31,6 @@ permalink: /development.html
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Obtaining The Source Code</h3>
     </div>
     <div class="section-item">
@@ -47,7 +44,6 @@ permalink: /development.html
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Compiling</h3>
     </div>
     <div class="section-item">
@@ -67,7 +63,6 @@ permalink: /development.html
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Development of NewGRF Extensions</h3>
     </div>
     <div class="section-item">
@@ -84,7 +79,6 @@ permalink: /development.html
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Development of AIs and Game Scripts</h3>
     </div>
     <div class="section-item">

--- a/pages/donate.html
+++ b/pages/donate.html
@@ -7,7 +7,6 @@ permalink: /donate.html
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Donate to OpenTTD</h3>
     </div>
     <div class="section-item">

--- a/pages/index.html
+++ b/pages/index.html
@@ -57,7 +57,6 @@ permalink: /index.html
             </div>
             <div id="section">
                 <div class="section-header">
-                    <div class="section-icon"></div>
                     <h3>Recent News</h3>
                 </div>
                 {% for post in site.posts limit: 5 %}

--- a/pages/index.html
+++ b/pages/index.html
@@ -37,23 +37,21 @@ permalink: /index.html
                 </div>
             </div>
             <div id="index-right">
-                <div id="screenshot">
+                <figure id="screenshot">
                     {% assign random_screenshot = site.screenshots | sample %}
-                    <div id="screenshot-image">
-                        <a href="{{ site.baseurl }}/screenshots.html">
-                            {% assign stripped_content = random_screenshot.content | strip_html | strip_newlines %}
-                            <img src="{{ site.baseurl }}{{ random_screenshot.id }}_thumb.png"
-                                alt="{{ stripped_content }}"
-                                title="{{ stripped_content | truncatewords: 5 }}"
-                                width="232"
-                                height="178"
-                                />
-                        </a>
-                    </div>
-                    <div id="screenshot-content">
+                    <a href="{{ site.baseurl }}/screenshots.html" id="screenshot-image">
+                        {% assign stripped_content = random_screenshot.content | strip_html | strip_newlines %}
+                        <img src="{{ site.baseurl }}{{ random_screenshot.id }}_thumb.png"
+                            alt=""
+                            title="{{ stripped_content | truncatewords: 5 }}"
+                            width="232"
+                            height="178"
+                            />
+                    </a>
+                    <figcaption>
                         {{ random_screenshot.content }}
-                    </div>
-                </div>
+                    </figcaption>
+                </figure>
             </div>
             <div id="section">
                 <div class="section-header">

--- a/pages/news_archive.html
+++ b/pages/news_archive.html
@@ -8,7 +8,6 @@ pagination:
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Archived News</h3>
     </div>
     {% for post in paginator.posts %}

--- a/pages/policy.html
+++ b/pages/policy.html
@@ -6,7 +6,6 @@ permalink: /policy.html
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Privacy Statement</h3>
     </div>
     <div class="section-item">
@@ -47,7 +46,6 @@ permalink: /policy.html
         </div>
     </div>
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>Cookies Policy</h3>
     </div>
     <div class="section-item">

--- a/pages/screenshots.html
+++ b/pages/screenshots.html
@@ -7,7 +7,6 @@ permalink: /screenshots.html
 
 <div id="section-full">
     <div class="section-header">
-        <div class="section-icon"></div>
         <h3>OpenTTD showcase</h3>
     </div>
     <div class="section-item">
@@ -20,7 +19,6 @@ permalink: /screenshots.html
     {% assign groups_sorted = groups | sort: "name" | reverse %}
     {% for group in groups_sorted %}
         <div class="section-header">
-            <div class="section-icon"></div>
             {% if group.name == "special" %}
                 <h3>Special screenshots</h3>
             {% else %}

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -87,20 +87,29 @@
 	width: 246px;
 }
 #screenshot {
+	margin: 0;       /* it's necessary to bring the margin to 0 because figure brings its own huge margin in most browsers */
 	font-size: 11px;
 }
 #screenshot-image {
+	display: block;
 	background-color: #FCB030;
-	padding: 6px 0px 0px 0px;
-	height: 184px;
+	padding: 6px;
 	text-align: center;
 }
 #screenshot-image img {
+	display: block;
+	margin: auto;
 	border: 1px solid #FFFFFF;
+	width: 100%;
+	height: auto;
 }
-#screenshot-content {
+#screenshot figcaption {
 	background-color: #FEE7C0;
 	padding: 10px 10px 10px 10px;
+	padding: 6px;
+}
+#screenshot figcaption > * {
+	margin: 0;
 }
 #donate {
 	background: url("../img/layout/section-donate-bg.png") repeat;

--- a/static/css/page.css
+++ b/static/css/page.css
@@ -14,15 +14,8 @@
 	text-align: left;
 	border-radius: 4px;
 }
-.section-icon {
-	background: url("../img/layout/section-news.gif") no-repeat;
-	float: left;
-	height: 28px;
-	margin-top: 5px;
-	padding-right: 6px;
-	width: 28px;
-}
 .section-header h3 {
+	background: url("../img/layout/section-news.gif") left center no-repeat;
 	font-size: 18px;
 	text-decoration: none;
 	padding: 0 0 0 32px;

--- a/static/css/page.css
+++ b/static/css/page.css
@@ -10,7 +10,7 @@
 	color: #365800;
 	line-height: 38px;
 	height: 38px;
-	padding: 0px 0px 0px 10px;
+	padding: 0 10px;
 	text-align: left;
 	border-radius: 4px;
 }
@@ -24,8 +24,8 @@
 }
 .section-header h3 {
 	font-size: 18px;
-	margin-right: 20px;
 	text-decoration: none;
+	padding: 0 0 0 32px;
 }
 
 .section-item {


### PR DESCRIPTION
It started as pure fixes but landed as medium changes.

## Icons in the headings

- adjusted the padding of the headings (`h3`) to leave place for the icons
- remove the margin from the headings and put a right padding to the containing `div` instead (same `10px` as left padding)
- remove all `div.section-icon` and put the icon to the headings itself, removed also the CSS-ruleset for `div.section-icon`

That makes the HTML-structure a bit smaller and simplifies the CSS-ruleset a bit

## Screenshot thumbnail on the home page

- replace the overly nested structure with `div`s with a `figure`-`figcaption` combination (HTML5 rules)
- removed the `div` for the `a` and the `img` in it and give its task directly to the `a`
- removed the height from `#screenshot-image` because the fixed height in combination with the `box-model: border-box;` caused the break mentioned in #130 
- complement the width- and height-attributes of the image with CSS-rules that makes the image large as possible in the main container `#index-right`
- removed the placeholder for the alt-attribute of the image because the planned content is the same as the description bbelow the image (now stored in `figcaption`); would be displayed twice when the image was broken and read twice for screenreader users. The alt-attribute itself has to stay there because if it would be removed, a screenreader would read the filename of the image.