### PR TITLE
Fix: better margin of logo on the banner

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -11,7 +11,10 @@
 #openttd-text {
 	color: #FFFFFF;
 	font-size: 24px;
-	max-width: 350px;
+	width: calc(100% - 33% - 128px - 30px - 15px);
+}
+#openttd-banner {
+	margin: 0 15px 0 30px;
 }
 #openttd-banner-left-1 {
 	background: linear-gradient(to right, #00000000 0%, #333333 75%), url("../img/teaser/1.png") no-repeat;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -5,10 +5,10 @@
 	display: flex;
 	height: 185px;
 	justify-content: space-between;
-	padding-left: 30px;
-	padding-right: 30px;
 	margin-bottom: 10px;
 	overflow: hidden;
+	padding-left: 30px;
+	padding-right: 30px;
 }
 #openttd-text {
 	color: #FFFFFF;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -4,17 +4,16 @@
 	border-radius: 6px;
 	display: flex;
 	height: 185px;
-	justify-content: space-around;
+	justify-content: space-between;
+	padding-left: 30px;
+	padding-right: 30px;
 	margin-bottom: 10px;
 	overflow: hidden;
 }
 #openttd-text {
 	color: #FFFFFF;
 	font-size: 24px;
-	width: calc(100% - 33% - 128px - 30px - 15px);
-}
-#openttd-banner {
-	margin: 0 15px 0 30px;
+	width: 350px;
 }
 #openttd-banner-left-1 {
 	background: linear-gradient(to right, #00000000 0%, #333333 75%), url("../img/teaser/1.png") no-repeat;
@@ -40,7 +39,6 @@
 
 #banner-links {
 	color: #CCCCCC;
-	width: 33%;
 }
 #banner-links ul li {
 	list-style-type: none;


### PR DESCRIPTION
It was spaced a bit too far to the left, which made it look off.

Old result:
![image](https://user-images.githubusercontent.com/1663690/71626816-66cb5080-2bef-11ea-8f45-29f5a0731258.png)

New result:
![image](https://user-images.githubusercontent.com/1663690/71627145-2e2c7680-2bf1-11ea-8d2e-fc02917e099c.png)
