### PR TITLE
More or less complete rework of the page header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,10 +36,8 @@
                 {% endif %}
                 <h5><a href="{{ site.baseurl }}{{ latest_nightly.url }}">Download nightly ({{ nightly_version }})</a></h5>
             </div>
-            <div id="header-logo">
-                <div id="openttd-logo">
-                    <div id="openttd-logo-text"><a href="{{ site.baseurl }}"><img src="{{ site.staticurl }}/img/layout/openttd-logo.png" alt="OpenTTD" /></a></div>
-                </div>
+            <div id="openttd-logo">
+                <div id="openttd-logo-text"><a href="{{ site.baseurl }}"><img src="{{ site.staticurl }}/img/layout/openttd-logo.png" alt="OpenTTD" /></a></div>
             </div>
         </header>
         <nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,13 +29,13 @@
             {% assign nightly_version = latest_nightly.version | split: "-" | slice: 0 %}
             {% endif %}
 
-            <div id="download-fast">
-                <h5><a href="{{ site.baseurl }}{{ latest_stable.url }}">Download stable ({{ latest_stable.version }})</a></h5>
+            <ul id="download-fast">
+                <li><a href="{{ site.baseurl }}{{ latest_stable.url }}">Download stable ({{ latest_stable.version }})</a></li>
                 {% if latest_stable.date < latest_testing.date %}
-                <h5><a href="{{ site.baseurl }}{{ latest_testing.url }}">Download testing ({{ latest_testing.version }})</a></h5>
+                <li><a href="{{ site.baseurl }}{{ latest_testing.url }}">Download testing ({{ latest_testing.version }})</a></li>
                 {% endif %}
-                <h5><a href="{{ site.baseurl }}{{ latest_nightly.url }}">Download nightly ({{ nightly_version }})</a></h5>
-            </div>
+                <li><a href="{{ site.baseurl }}{{ latest_nightly.url }}">Download nightly ({{ nightly_version }})</a></li>
+            </ul>
             <div id="openttd-logo">
                 <div id="openttd-logo-text"><a href="{{ site.baseurl }}"><img src="{{ site.staticurl }}/img/layout/openttd-logo.png" alt="OpenTTD" /></a></div>
             </div>

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -64,13 +64,15 @@ body > header {
 	box-shadow: 0px 0px 5px #000000;
 	/* Stripes! */
 	background-image: repeating-linear-gradient(to bottom, #323536 0, #323536 1px, #3c3e40 1px, #3c3e40 2px);
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
 }
 
 #download-fast {
 	background: url("../img/layout/download-package.gif") 12px 50% no-repeat, rgba(85, 87, 89, 0.4);
 	border: 0 solid;
 	border-radius: 6px;
-	float: left;
 	line-height: 12px;
 	margin: 22px 0px 0px 10px;
 	padding: 9px 12px 9px 45px;
@@ -86,7 +88,6 @@ body > header {
 }
 
 #header-logo {
-	float: right;
 	width: 400px;
 }
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -73,18 +73,22 @@ body > header {
 	background: url("../img/layout/download-package.gif") 12px 50% no-repeat, rgba(85, 87, 89, 0.4);
 	border: 0 solid;
 	border-radius: 6px;
-	line-height: 12px;
-	margin: 22px 0px 0px 10px;
-	padding: 9px 12px 9px 45px;
+	list-style: none;
+	margin: 0;
+	padding: 3px 10px 3px 45px;
 	text-align: left;
 }
-#download-fast h5 a {
-	color: #CCCCCC;
+#download-fast li:not(:last-child) {
+	margin: 0 0 2px 0;
+}
+#download-fast a {
+	color: #ccc;
 	font-size: 11px;
 	text-decoration: none;
 }
-#download-fast h5 a:focus, #download-fast h5 a:hover {
-	color: #999999;
+#download-fast a:focus, #download-fast a:hover {
+	color: #999;
+	text-decoration: underline;
 }
 
 #openttd-logo {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -95,36 +95,31 @@ body > header {
 	background: url("../img/layout/openttd-64.gif") no-repeat left bottom 2px;
 	height: 68px;
 	width: 250px;
+	position: relative;
 }
-#openttd-logo-text {
-	height: 29px;
-	margin: 36px 0px 0px 77px;
-	width: 151px;
+#openttd-logo-text,
+#openttd-logo-text img,
+#openttd-logo-text-noai,
+#openttd-logo-text-noai img,
+#openttd-logo-text-bananas,
+#openttd-logo-text-bananas img,
+#openttd-logo-text-security,
+#openttd-logo-text-security img,
+#openttd-logo-text-binaries,
+#openttd-logo-text-binaries img,
+#openttd-logo-text-translator,
+#openttd-logo-text-translator img {
+	display: block;
 }
-#openttd-logo-text-noai {
-	height: 29px;
-	margin: 15px 0px 0px 75px;
-	width: 151px;
-}
-#openttd-logo-text-bananas {
-	height: 29px;
-	margin: 18px 0px 0px 75px;
-	width: 151px;
-}
-#openttd-logo-text-security {
-	height: 29px;
-	margin: 18px 0px 0px 75px;
-	width: 151px;
-}
-#openttd-logo-text-binaries {
-	height: 29px;
-	margin: 36px 0px 0px 77px;
-	width: 151px;
-}
+#openttd-logo-text,
+#openttd-logo-text-noai,
+#openttd-logo-text-bananas,
+#openttd-logo-text-security,
+#openttd-logo-text-binaries,
 #openttd-logo-text-translator {
-	height: 29px;
-	margin: 28px 0px 0px 75px;
-	width: 151px;
+	position: absolute;
+	bottom: 4px;
+	left: 78px;
 }
 
 body > nav {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -63,8 +63,7 @@ body > header {
 	margin: 0px auto;
 	box-shadow: 0px 0px 5px #000000;
 	/* Stripes! */
-	background-image: linear-gradient(0deg, #323536 50%, #3c3e40 50%, #3c3e40 100%);
-	background-size: 2px 2px;
+	background-image: repeating-linear-gradient(to bottom, #323536 0, #323536 1px, #3c3e40 1px, #3c3e40 2px);
 }
 
 #download-fast {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -59,8 +59,8 @@ body > * {
 }
 
 body > header {
-	height: 90px;
 	margin: 0px auto;
+	padding: 6px 10px 10px 10px;
 	box-shadow: 0px 0px 5px #000000;
 	/* Stripes! */
 	background-image: repeating-linear-gradient(to bottom, #323536 0, #323536 1px, #3c3e40 1px, #3c3e40 2px);
@@ -94,9 +94,7 @@ body > header {
 #openttd-logo {
 	background: url("../img/layout/openttd-64.gif") no-repeat;
 	background-position: left center;
-	float: right;
-	height: 75px;
-	margin-top: 6px;
+	height: 68px;
 	width: 250px;
 }
 #openttd-logo-text {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -92,8 +92,7 @@ body > header {
 }
 
 #openttd-logo {
-	background: url("../img/layout/openttd-64.gif") no-repeat;
-	background-position: left center;
+	background: url("../img/layout/openttd-64.gif") no-repeat left bottom 2px;
 	height: 68px;
 	width: 250px;
 }

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -87,10 +87,6 @@ body > header {
 	color: #999999;
 }
 
-#header-logo {
-	width: 400px;
-}
-
 #openttd-logo {
 	background: url("../img/layout/openttd-64.gif") no-repeat;
 	background-position: left center;


### PR DESCRIPTION
Because of the rtl-issue, desccribed in #117, I began to rework the header section. Follwoing changes are part of the PR.

- organised the header as a flexbox
- rebuilt the download-fast-box as a list
- simplified the structure of the logo-container
- putting all background-related rules (image, position, size) into the shorthand `background`
- removed several height and width values because the boxes takes the necessary space themself

I have a question about tha last point. I added the whole list of selectors whose names begins with `#openttd-logo-text` but I have no clue if some of them might be not in use here. Some of them i.e. like *-bananas, *-noai seems to be intended for use on different subdomains. Are there selectors I can remove without breaking things on another place?

**Edit:** Forgot to add the screenshots for ltr (left-to-right-languages) and rtl ones.

left to right:
![header of the OpenTTD-website in left to right mode](https://user-images.githubusercontent.com/1734660/71676706-2ef41280-2d81-11ea-9352-0a82b96822a0.png)

right to left:
![header of the OpenTTD-website in right to left mode](https://user-images.githubusercontent.com/1734660/71676764-5a76fd00-2d81-11ea-932e-73bda91c5297.png)
