### PR TITLE
Fix: logo in top-right corner wasn't pointing to "Home"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,7 +37,7 @@
                 <li><a href="{{ site.baseurl }}{{ latest_nightly.url }}">Download nightly ({{ nightly_version }})</a></li>
             </ul>
             <div id="openttd-logo">
-                <div id="openttd-logo-text"><a href="{{ site.baseurl }}"><img src="{{ site.staticurl }}/img/layout/openttd-logo.png" alt="OpenTTD" /></a></div>
+                <div id="openttd-logo-text"><a href="{{ site.baseurl }}/"><img src="{{ site.staticurl }}/img/layout/openttd-logo.png" alt="OpenTTD" /></a></div>
             </div>
         </header>
         <nav>


### PR DESCRIPTION
This is because there was a / missing after "baseurl", which is
present for all other links.

Fixes #139