### PR TITLE
Fix: links to documentation have changed

### DIFF
--- a/pages/development.html
+++ b/pages/development.html
@@ -86,8 +86,8 @@ permalink: /development.html
             <p>OpenTTD provides a script interface, which is used to provide computer players or altered game behaviour and goals.</p>
             <p>Scripts and associated libraries are written in squirrel (version 2) and need to make use of OpenTTD's API for Scripts. Useful resources include:</p>
             <ul>
-                <li><a href="https://noai.openttd.org/api/">NoAI API</a> API for OpenTTD's AIs.</li>
-                <li><a href="https://nogo.openttd.org/api/">NoGo API</a> API for OpenTTD's Game Scripts.</li>
+                <li><a href="https://docs.openttd.org/ai-api/">NoAI API</a> API for OpenTTD's AIs.</li>
+                <li><a href="https://docs.openttd.org/gs-api/">NoGo API</a> API for OpenTTD's Game Scripts.</li>
                 <li><a href="https://wiki.openttd.org/AI:Main_Page">Wiki</a>  Wiki section dedicated to Script development.</li>
                 <li><a href="https://www.tt-forums.net/viewforum.php?f=65">Forum</a> Forum dedicated to OpenTTD's Script development.</li>
                 <li><a href="http://squirrel-lang.org/doc/squirrel2.html">Squirrel 2 Reference</a> Reference manual for the squirrel language.</li>


### PR DESCRIPTION
All documentation is now available on https://docs.openttd.org/.