### PR TITLE
Fix: redirect non-latest releases to the CDN directly

### DIFF
--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -41,6 +41,18 @@ server {
     # For some time, openttd-useful was not marked as "release", making it an odd duck
     location ~ ^/downloads/openttd-useful/(.*) { return 301 $scheme://$http_host/downloads/openttd-useful-releases/$1; }
 
+    # Non-latest are no longer served via this container; they can be found on the CDN
+    location ~ ^/downloads/catcodec-releases/([\d].*).html$ { return 301 $scheme://cdn.openttd.org/catcodec-releases/$1/; }
+    location ~ ^/downloads/grfcodec-releases/([\d].*).html$ { return 301 $scheme://cdn.openttd.org/grfcodec-releases/$1/; }
+    location ~ ^/downloads/nforenum-releases/([\d].*).html$ { return 301 $scheme://cdn.openttd.org/nforenum-releases/$1/; }
+    location ~ ^/downloads/nosound-releases/([\d].*).html$ { return 301 $scheme://cdn.openttd.org/nosound-releases/$1/; }
+    location ~ ^/downloads/opengfx-releases/([\d].*).html$ { return 301 $scheme://cdn.openttd.org/opengfx-releases/$1/; }
+    location ~ ^/downloads/openmsx-releases/([\d].*).html$ { return 301 $scheme://cdn.openttd.org/openmsx-releases/$1/; }
+    location ~ ^/downloads/opensfx-releases/([\d].*).html$ { return 301 $scheme://cdn.openttd.org/opensfx-releases/$1/; }
+    location ~ ^/downloads/openttd-releases/([\d].*).html$ { return 301 $scheme://cdn.openttd.org/openttd-releases/$1/; }
+    location ~ ^/downloads/openttd-useful-releases/([\d].*).html$ { return 301 $scheme://cdn.openttd.org/openttd-useful-releases/$1/; }
+    location ~ ^/downloads/osie-releases/([\d].*).html$ { return 301 $scheme://cdn.openttd.org/osie-releases/$1/; }
+
     ### Below are redirects to support old URLs of our previous Django-based website
 
     # Main pages


### PR DESCRIPTION
As we no longer publish non-latest on the website, send them to
somewhere where the files are still available.

Fixes #149