### PR TITLE
Include final URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   An open source simulator based on the classic game Transport Tycoon Deluxe. It attempts to mimic the original game as closely as possible while extending it with new features.
 baseurl: ""
 staticurl: /static
-url: ""
+url: "https://www.openttd.org/"
 timezone: Etc/UTC
 excerpt_separator: <!-- more -->
 future: true


### PR DESCRIPTION
The site is available on that particular URL, so include it on the URL configuration.

This should fix the errors I get on the feed generation.

https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fwww.openttd.org%2Ffeed.xml

The feed itself does not validate, but this is kinda strange, because my feed reader accepts with weird post URLs.