### PR TITLE
Fix: paddings in website footer

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -175,12 +175,12 @@ body > footer {
 #content-bottom-links {
 	float: left;
 	font-size: 11px;
-	padding: 7px 5px 0px 5px;
+	padding: 3px 5px 3px 5px;
 }
 #content-bottom-copyright {
 	float: right;
 	font-size: 11px;
-	padding: 7px 5px 0px 5px;
+	padding: 3px 5px 3px 5px;
 }
 #hr-clear {
 	clear: both;

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -175,12 +175,12 @@ body > footer {
 #content-bottom-links {
 	float: left;
 	font-size: 11px;
-	padding: 3px 5px 3px 5px;
+	padding: 3px 5px;
 }
 #content-bottom-copyright {
 	float: right;
 	font-size: 11px;
-	padding: 3px 5px 3px 5px;
+	padding: 3px 5px;
 }
 #hr-clear {
 	clear: both;


### PR DESCRIPTION
See OpenTTD/website#117

They were originally lopsided, but now it's about equal on both sides.

Before:
![image](https://user-images.githubusercontent.com/37945304/83520540-7521df00-a4a3-11ea-8b14-75c5924dc6e0.png)

After: 
![image](https://user-images.githubusercontent.com/37945304/83520708-bd410180-a4a3-11ea-84eb-434a7eca67a5.png)