### PR TITLE
Add: port the security patches we have for CVEs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,11 @@ defaults:
       type: "screenshots"
     values:
       layout: "screenshot"
+  - scope:
+      path: ""
+      type: "security"
+    values:
+      layout: "security"
 
 collections:
   downloads:
@@ -53,6 +58,8 @@ collections:
   posts:
     permalink: /news/:year/:month/:day/:title.html
   screenshots:
+    output: true
+  security:
     output: true
 
 pagination:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,9 @@
         {% for filename in layout.css %}
         <link rel="stylesheet" href="{{ site.staticurl }}/css/{{ filename }}" type="text/css" />
         {% endfor %}
+        {% for filename in page.css %}
+        <link rel="stylesheet" href="{{ site.staticurl }}/css/{{ filename }}" type="text/css" />
+        {% endfor %}
         {% for filename in layout.js %}
         <script type="text/javascript" src="{{ site.staticurl }}/js/{{ filename }}"></script>
         {% endfor %}
@@ -41,6 +44,13 @@
             </div>
         </header>
         <nav>
+            {% if page.active_nav == 'security' or layout.active_nav == 'security' %}
+            <ul id="navigation-bar">
+                <li class="">
+                    <a href="{{ site.baseurl }}/security.html">Security tracker</a>
+                </li>
+            </ul>
+            {% else %}
             <ul id="navigation-bar">
                 <li class="{% if page.active_nav == 'home' %}selected{% endif %}">
                     <a href="{{ site.baseurl }}/">Home</a>
@@ -65,6 +75,7 @@
                     <a href="{{ site.baseurl }}/donate.html">Donate</a>
                 </li>
             </ul>
+            {% endif %}
         </nav>
         <main>
             {{ content }}

--- a/_layouts/security.html
+++ b/_layouts/security.html
@@ -1,0 +1,40 @@
+---
+layout: default
+active_nav: security
+section_title: Security
+---
+
+<div id="section-full">
+    <div class="section-header">
+        <h3>{{ page.name }} (vulnerable {{ page.first_vulnerable }} - fixed {{ page.first_fixed }})</h3>
+    </div>
+    <div class="section-item">
+        <div class="content">
+            <p>Short description: {{ page.description }}</p>
+            <p><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name={{ page.name }}" target="_blank">Official {{ page.name }} entry at cve.mitre.org.</a></p>
+            <p>Related bug reports:</p>
+            <ul>
+                {% if page.related_bugs != "" %}
+                    {% for related_bug in page.related_bugs %}
+                    <li><a href="https://github.com/OpenTTD/OpenTTD/issues/{{ related_bug }}" target="_blank">GitHub Issue #{{ related_bug }}</a></li>
+                    {% endfor %}
+                {% else %}
+                    <li>There are no related bugs.</li>
+                {% endif %}
+            </ul>
+            <p>Related commits:</p>
+            <ul>
+                {% for related_commit in page.related_commits %}
+                <li><a href="https://github.com/OpenTTD/OpenTTD/commit/{{ related_commit }}" target="_blank">{{ related_commit }}</a></li>
+                {% endfor %}
+            </ul>
+            <p>Patches: (sometimes more fuzz is needed to apply them)</p>
+            <ul>
+                {% for patch in page.patches %}
+                <li><a href="{{ site.baseurl }}{{ page.id }}/{{ patch.file }}" target="_blank">{{ patch.name }}</a></li>
+                {% endfor %}
+            </ul>
+            <p>{{ page.content }}</p>
+        </div>
+    </div>
+</div>

--- a/_layouts/security_patch.html
+++ b/_layouts/security_patch.html
@@ -1,0 +1,8 @@
+{% assign security = site.security | where: "name", page.cve | first %}Subject: fix for vulnerability {{ security.name }} for OpenTTD {{ page.first_version }} - {{ page.last_version }} ({{ security.description }})
+From: OpenTTD developer team <info@openttd.org>
+Origin: backport,{% for related_commit in security.related_commits %} https://github.com/OpenTTD/OpenTTD/commit/{{ related_commit }}{% endfor %}
+Bug:{% for related_bug in security.related_bugs %} https://github.com/OpenTTD/OpenTTD/issues/{{ related_bug }}{% endfor %}
+
+{{ security.content | strip_html }}
+
+{{ page.content }}

--- a/_security/CVE-2005-2763.md
+++ b/_security/CVE-2005-2763.md
@@ -1,0 +1,20 @@
+---
+name: CVE-2005-2763
+description: Multiple format string vulnerabilities
+first_vulnerable: 0.3.5
+first_fixed: 0.4.5
+related_bugs: []
+related_commits:
+- d975abc
+patches:
+- name: For version 0.4.0 up to including 0.4.0.1
+  file: 0.4.0 - 0.4.0.1.patch
+- name: For version 0.3.5 up to including 0.3.5
+  file: 0.3.5 - 0.3.5.patch
+---
+
+Format string vulnerabilities where the client's name or leave message would
+be interpreted as a format string. This can cause crashes of the server, i.e.
+denial of service, or possibly execution of arbitrary code.
+
+Note that this is a partial backport of trunk r2899.

--- a/_security/CVE-2005-2763/0.3.5 - 0.3.5.patch
+++ b/_security/CVE-2005-2763/0.3.5 - 0.3.5.patch
@@ -1,0 +1,64 @@
+---
+layout: security_patch
+cve: CVE-2005-2763
+first_version: 0.3.5
+last_version: 0.3.5
+---
+
+Index: network_client.c
+===================================================================
+--- network_client.c
++++ network_client.c
+@@ -344,7 +344,7 @@
+ 	if (ci != NULL) {
+ 		if (playas == ci->client_playas && strcmp(name, ci->client_name) != 0) {
+ 			// Client name changed, display the change
+-			NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, name);
++			NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, "%s", name);
+ 		} else if (playas != ci->client_playas) {
+ 			// The player changed from client-player..
+ 			// Do not display that for now
+@@ -687,7 +687,7 @@
+
+ 	ci = NetworkFindClientInfoFromIndex(index);
+ 	if (ci != NULL) {
+-		NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, ci->client_name, str);
++		NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, ci->client_name, "%s", str);
+
+ 		// The client is gone, give the NetworkClientInfo free
+ 		ci->client_index = NETWORK_EMPTY_INDEX;
+Index: console_cmds.c
+===================================================================
+--- console_cmds.c
++++ console_cmds.c
+@@ -706,7 +706,7 @@
+ 				SEND_COMMAND(PACKET_CLIENT_SET_NAME)(argv[2]);
+ 			else {
+ 				if (NetworkFindName(argv[2])) {
+-					NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, argv[2]);
++					NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, "%s", argv[2]);
+ 					ttd_strlcpy(ci->client_name, argv[2], sizeof(ci->client_name));
+ 					NetworkUpdateClientInfo(NETWORK_SERVER_INDEX);
+ 				}
+Index: network_server.c
+===================================================================
+--- network_server.c
++++ network_server.c
+@@ -936,7 +936,7 @@
+
+ 	NetworkGetClientName(client_name, sizeof(client_name), cs);
+
+-	NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, client_name, str);
++	NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, client_name, "%s", str);
+
+ 	FOR_ALL_CLIENTS(new_cs) {
+ 		if (new_cs->status > STATUS_AUTH) {
+@@ -1111,7 +1111,7 @@
+ 	if (ci != NULL) {
+ 		// Display change
+ 		if (NetworkFindName(client_name)) {
+-			NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, client_name);
++			NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, "%s", client_name);
+ 			ttd_strlcpy(ci->client_name, client_name, sizeof(ci->client_name));
+ 			NetworkUpdateClientInfo(ci->client_index);
+ 		}

--- a/_security/CVE-2005-2763/0.4.0 - 0.4.0.1.patch
+++ b/_security/CVE-2005-2763/0.4.0 - 0.4.0.1.patch
@@ -1,0 +1,64 @@
+---
+layout: security_patch
+cve: CVE-2005-2763
+first_version: 0.4.0
+last_version: 0.4.0.1
+---
+
+Index: network_client.c
+===================================================================
+--- network_client.c
++++ network_client.c
+@@ -344,7 +344,7 @@
+ 	if (ci != NULL) {
+ 		if (playas == ci->client_playas && strcmp(name, ci->client_name) != 0) {
+ 			// Client name changed, display the change
+-			NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, name);
++			NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, "%s", name);
+ 		} else if (playas != ci->client_playas) {
+ 			// The player changed from client-player..
+ 			// Do not display that for now
+@@ -687,7 +687,7 @@
+
+ 	ci = NetworkFindClientInfoFromIndex(index);
+ 	if (ci != NULL) {
+-		NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, ci->client_name, str);
++		NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, ci->client_name, "%s", str);
+
+ 		// The client is gone, give the NetworkClientInfo free
+ 		ci->client_index = NETWORK_EMPTY_INDEX;
+Index: console_cmds.c
+===================================================================
+--- console_cmds.c
++++ console_cmds.c
+@@ -1101,7 +1101,7 @@
+ 			SEND_COMMAND(PACKET_CLIENT_SET_NAME)(_network_player_name);
+ 		} else {
+ 			if (NetworkFindName(_network_player_name)) {
+-				NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, _network_player_name);
++				NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, "%s", _network_player_name);
+ 				ttd_strlcpy(ci->client_name, _network_player_name, sizeof(ci->client_name));
+ 				NetworkUpdateClientInfo(NETWORK_SERVER_INDEX);
+ 			}
+Index: network_server.c
+===================================================================
+--- network_server.c
++++ network_server.c
+@@ -936,7 +936,7 @@
+
+ 	NetworkGetClientName(client_name, sizeof(client_name), cs);
+
+-	NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, client_name, str);
++	NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, client_name, "%s", str);
+
+ 	FOR_ALL_CLIENTS(new_cs) {
+ 		if (new_cs->status > STATUS_AUTH) {
+@@ -1111,7 +1111,7 @@
+ 	if (ci != NULL) {
+ 		// Display change
+ 		if (NetworkFindName(client_name)) {
+-			NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, client_name);
++			NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, 1, false, ci->client_name, "%s", client_name);
+ 			ttd_strlcpy(ci->client_name, client_name, sizeof(ci->client_name));
+ 			NetworkUpdateClientInfo(ci->client_index);
+ 		}

--- a/_security/CVE-2005-2764.md
+++ b/_security/CVE-2005-2764.md
@@ -1,0 +1,21 @@
+---
+name: CVE-2005-2764
+description: Multiple buffer overflows
+first_vulnerable: 0.1.0
+first_fixed: 0.4.5
+related_bugs: []
+related_commits: []
+patches:
+- name: For version 0.3.5 up to including 0.4.0.1
+  file: 0.3.5 - 0.4.0.1.patch
+---
+
+Multiple format string vulnerabilities that allow remote attackers to cause a
+denial of service (crash) and possibly execute arbitrary code via unspecified
+vectors.
+
+Attached are patches for some vulnerable versions. Versions from before 0.3.5
+had no (good) functioning network play. Making patches for those versions is
+quite easy as it is replacing "vsprintf(a" with "vsnprintf(a, sizeof(a)".
+
+Note: this is a partial backport of trunk r2899.

--- a/_security/CVE-2005-2764/0.3.5 - 0.4.0.1.patch
+++ b/_security/CVE-2005-2764/0.3.5 - 0.4.0.1.patch
@@ -1,0 +1,112 @@
+---
+layout: security_patch
+cve: CVE-2005-2764
+first_version: 0.3.5
+last_version: 0.4.0.1
+---
+
+Index: network.c
+===================================================================
+--- network.c
++++ network.c
+@@ -96,7 +96,7 @@
+ 	StringID TempStr = STR_NULL;
+
+ 	va_start(va, str);
+-	vsprintf(buf, str, va);
++	vsnprintf(buf, sizeof(buf), str, va);
+ 	va_end(va);
+
+ 	switch (action) {
+Index: ttd.c
+===================================================================
+--- ttd.c
++++ ttd.c
+@@ -70,7 +70,7 @@
+ 	va_list va;
+ 	char buf[512];
+ 	va_start(va, s);
+-	vsprintf(buf, s, va);
++	vsnprintf(buf, sizeof(buf), s, va);
+ 	va_end(va);
+
+ 	ShowOSErrorBox(buf);
+@@ -86,7 +86,7 @@
+ 	va_list va;
+ 	char buf[1024];
+ 	va_start(va, str);
+-	vsprintf(buf, str, va);
++	vsnprintf(buf, sizeof(buf), str, va);
+ 	va_end(va);
+ 	ShowInfo(buf);
+ }
+@@ -99,7 +99,7 @@
+ 	char *p;
+
+ 	va_start(va, str);
+-	len = vsprintf(buf, str, va);
++	len = vsnprintf(buf, sizeof(buf), str, va);
+ 	va_end(va);
+ 	p = malloc(len + 1);
+ 	if (p)
+Index: texteff.c
+===================================================================
+--- texteff.c
++++ texteff.c
+@@ -57,7 +57,7 @@
+ 	int length;
+
+ 	va_start(va, message);
+-	vsprintf(buf, message, va);
++	vsnprintf(buf, sizeof(buf), message, va);
+ 	va_end(va);
+
+ 	/* Special color magic */
+Index: win32.c
+===================================================================
+--- win32.c
++++ win32.c
+@@ -841,7 +841,7 @@
+ 	char buf[512];
+
+ 	va_start(va, cmd);
+-	vsprintf(buf, cmd, va);
++	vsnprintf(buf, sizeof(buf), cmd, va);
+ 	va_end(va);
+ 	return mciSendStringA(buf, NULL, 0, 0);
+ }
+Index: os2.c
+===================================================================
+--- os2.c
++++ os2.c
+@@ -642,7 +642,7 @@
+ 	va_list va;
+ 	char buf[512];
+ 	va_start(va, cmd);
+-	vsprintf(buf, cmd, va);
++	vsnprintf(buf, sizeof(buf), cmd, va);
+ 	va_end(va);
+ 	return mciSendString(buf, NULL, 0, NULL, 0);
+ }
+Index: strgen/strgen.c
+===================================================================
+--- strgen/strgen.c
++++ strgen/strgen.c
+@@ -84,7 +84,7 @@
+ 	char buf[1024];
+ 	va_list va;
+ 	va_start(va, s);
+-	vsprintf(buf, s, va);
++	vsnprintf(buf, sizeof(buf), s, va);
+ 	va_end(va);
+ 	fprintf(stderr, "%d: ERROR: %s\n", _cur_line, buf);
+ 	_warnings = true;
+@@ -94,7 +94,7 @@
+ 	char buf[1024];
+ 	va_list va;
+ 	va_start(va, s);
+-	vsprintf(buf, s, va);
++	vsnprintf(buf, sizeof(buf), s, va);
+ 	va_end(va);
+ 	fprintf(stderr, "%d: FATAL: %s\n", _cur_line, buf);
+ 	exit(1);

--- a/_security/CVE-2006-1998.md
+++ b/_security/CVE-2006-1998.md
@@ -1,0 +1,28 @@
+---
+name: CVE-2006-1998
+description: Denial of service (server) via invalid error number
+first_vulnerable: 0.3.5
+first_fixed: 0.4.8
+related_bugs: []
+related_commits:
+- 7d232cf
+- e9a5ca7
+- 1c5c32d
+patches:
+- name: For version 0.4.5 up to including 0.4.7
+  file: 0.4.5 - 0.4.7.patch
+- name: For version 0.4.0 up to including 0.4.0.1
+  file: 0.4.0 - 0.4.0.1.patch
+- name: For version 0.3.5 up to including 0.3.5
+  file: 0.3.5 - 0.3.5.patch
+---
+
+Both client and server handle a type of command (PACKET_SERVER_ERROR
+and PACKET_CLIENT_ERROR) for the visualization of some pre-built errors
+in the console.
+The problem happens when an attacker sends an invalid big error number
+(8 bit) which forces the program to terminate spontaneously through the
+usage of the error() function.
+The bug is exploitable only in-game so the attacker must have access to
+the server: his IP must not be banned, he must know the password if it
+has been set and the server must not be full.

--- a/_security/CVE-2006-1998/0.3.5 - 0.3.5.patch
+++ b/_security/CVE-2006-1998/0.3.5 - 0.3.5.patch
@@ -1,0 +1,131 @@
+---
+layout: security_patch
+cve: CVE-2006-1998
+first_version: 0.3.5
+last_version: 0.3.5
+---
+
+Index: network.c
+===================================================================
+--- network.c
++++ network.c
+@@ -256,6 +256,35 @@
+ 	_networking = false;
+ }
+
++/** Retrieve a string representation of an internal error number
++ * @param buf buffer where the error message will be stored
++ * @param err NetworkErrorCode (integer)
++ * @return returns a pointer to the error message (buf) */
++char *GetNetworkErrorMsg(char *buf, NetworkErrorCode err)
++{
++	/* List of possible network errors, used by
++	 * PACKET_SERVER_ERROR and PACKET_CLIENT_ERROR */
++	static const StringID network_error_strings[] = {
++		STR_NETWORK_ERR_CLIENT_GENERAL,
++		STR_NETWORK_ERR_CLIENT_DESYNC,
++		STR_NETWORK_ERR_CLIENT_SAVEGAME,
++		STR_NETWORK_ERR_CLIENT_CONNECTION_LOST,
++		STR_NETWORK_ERR_CLIENT_PROTOCOL_ERROR,
++		STR_NETWORK_ERR_CLIENT_NOT_AUTHORIZED,
++		STR_NETWORK_ERR_CLIENT_NOT_EXPECTED,
++		STR_NETWORK_ERR_CLIENT_WRONG_REVISION,
++		STR_NETWORK_ERR_CLIENT_NAME_IN_USE,
++		STR_NETWORK_ERR_CLIENT_WRONG_PASSWORD,
++		STR_NETWORK_ERR_CLIENT_PLAYER_MISMATCH,
++		STR_NETWORK_ERR_CLIENT_KICKED,
++		STR_NETWORK_ERR_CLIENT_CHEATER,
++	};
++
++	if (err >= lengthof(network_error_strings)) err = 0;
++
++	return GetString(buf, network_error_strings[err]);
++}
++
+ // Find all IP-aliases for this host
+ static void NetworkFindIPs(void)
+ {
+@@ -524,7 +554,7 @@
+
+ 		NetworkGetClientName(client_name, sizeof(client_name), cs);
+
+-		GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + errorno);
++		GetNetworkErrorMsg(str, errorno);
+
+ 		NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, client_name, "%s", str);
+
+Index: network_data.h
+===================================================================
+--- network_data.h
++++ network_data.h
+@@ -230,6 +230,7 @@
+ NetworkClientInfo *NetworkFindClientInfoFromIP(const char *ip);
+ NetworkClientState *NetworkFindClientStateFromIndex(uint16 client_index);
+ unsigned long NetworkResolveHost(const char *hostname);
++char *GetNetworkErrorMsg(char *buf, NetworkErrorCode err);
+
+ #endif /* ENABLE_NETWORK */
+
+Index: network_client.c
+===================================================================
+--- network_client.c
++++ network_client.c
+@@ -683,16 +683,13 @@
+
+ DEF_CLIENT_RECEIVE_COMMAND(PACKET_SERVER_ERROR_QUIT)
+ {
+-	int errorno;
+ 	char str[100];
+ 	uint16 index;
+ 	NetworkClientInfo *ci;
+
+ 	index = NetworkRecv_uint16(p);
+-	errorno = NetworkRecv_uint8(p);
++	GetNetworkErrorMsg(str, NetworkRecv_uint8(p));
+
+-	GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + errorno);
+-
+ 	ci = NetworkFindClientInfoFromIndex(index);
+ 	if (ci != NULL) {
+ 		NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, ci->client_name, "%s", str);
+Index: network_server.c
+===================================================================
+--- network_server.c
++++ network_server.c
+@@ -29,8 +29,6 @@
+
+ void NetworkPopulateCompanyInfo(void);
+
+-// Is the network enabled?
+-
+ // **********
+ // Sending functions
+ //   DEF_SERVER_SEND_COMMAND has parameter: NetworkClientState *cs
+@@ -148,7 +146,7 @@
+ 	if (cs->status > STATUS_AUTH) {
+ 		NetworkGetClientName(client_name, sizeof(client_name), cs);
+
+-		GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + error);
++		GetNetworkErrorMsg(str, error);
+
+ 		DEBUG(net, 2)("[NET] %s made an error (%s) and his connection is closed", client_name, str);
+
+@@ -890,8 +889,8 @@
+ 	// This packets means a client noticed an error and is reporting this
+ 	//  to us. Display the error and report it to the other clients
+ 	NetworkClientState *new_cs;
+-	byte errorno = NetworkRecv_uint8(p);
+ 	char str[100];
++	NetworkErrorCode errorno = NetworkRecv_uint8(p);
+ 	char client_name[NETWORK_CLIENT_NAME_LENGTH];
+
+ 	// The client was never joined.. thank the client for the packet, but ignore it
+@@ -902,7 +901,7 @@
+
+ 	NetworkGetClientName(client_name, sizeof(client_name), cs);
+
+-	GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + errorno);
++	GetNetworkErrorMsg(str, errorno);
+
+ 	DEBUG(net, 2)("[NET] %s reported an error and is closing his connection (%s)", client_name, str);
+

--- a/_security/CVE-2006-1998/0.4.0 - 0.4.0.1.patch
+++ b/_security/CVE-2006-1998/0.4.0 - 0.4.0.1.patch
@@ -1,0 +1,131 @@
+---
+layout: security_patch
+cve: CVE-2006-1998
+first_version: 0.4.0
+last_version: 0.4.0.1
+---
+
+Index: network.c
+===================================================================
+--- network.c	(revision 19646)
++++ network.c	(working copy)
+@@ -237,6 +237,35 @@
+ 	_networking = false;
+ }
+
++/** Retrieve a string representation of an internal error number
++ * @param buf buffer where the error message will be stored
++ * @param err NetworkErrorCode (integer)
++ * @return returns a pointer to the error message (buf) */
++char *GetNetworkErrorMsg(char *buf, NetworkErrorCode err)
++{
++	/* List of possible network errors, used by
++	 * PACKET_SERVER_ERROR and PACKET_CLIENT_ERROR */
++	static const StringID network_error_strings[] = {
++		STR_NETWORK_ERR_CLIENT_GENERAL,
++		STR_NETWORK_ERR_CLIENT_DESYNC,
++		STR_NETWORK_ERR_CLIENT_SAVEGAME,
++		STR_NETWORK_ERR_CLIENT_CONNECTION_LOST,
++		STR_NETWORK_ERR_CLIENT_PROTOCOL_ERROR,
++		STR_NETWORK_ERR_CLIENT_NOT_AUTHORIZED,
++		STR_NETWORK_ERR_CLIENT_NOT_EXPECTED,
++		STR_NETWORK_ERR_CLIENT_WRONG_REVISION,
++		STR_NETWORK_ERR_CLIENT_NAME_IN_USE,
++		STR_NETWORK_ERR_CLIENT_WRONG_PASSWORD,
++		STR_NETWORK_ERR_CLIENT_PLAYER_MISMATCH,
++		STR_NETWORK_ERR_CLIENT_KICKED,
++		STR_NETWORK_ERR_CLIENT_CHEATER,
++	};
++
++	if (err >= lengthof(network_error_strings)) err = 0;
++
++	return GetString(buf, network_error_strings[err]);
++}
++
+ // Find all IP-aliases for this host
+ static void NetworkFindIPs(void)
+ {
+@@ -505,7 +534,7 @@
+
+ 		NetworkGetClientName(client_name, sizeof(client_name), cs);
+
+-		GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + errorno);
++		GetNetworkErrorMsg(str, errorno);
+
+ 		NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, client_name, str);
+
+Index: network_data.h
+===================================================================
+--- network_data.h	(revision 19646)
++++ network_data.h	(working copy)
+@@ -226,6 +226,7 @@
+ NetworkClientInfo *NetworkFindClientInfoFromIndex(uint16 client_index);
+ NetworkClientState *NetworkFindClientStateFromIndex(uint16 client_index);
+ unsigned long NetworkResolveHost(const char *hostname);
++char *GetNetworkErrorMsg(char *buf, NetworkErrorCode err);
+
+ #endif /* ENABLE_NETWORK */
+
+Index: network_client.c
+===================================================================
+--- network_client.c	(revision 19646)
++++ network_client.c	(working copy)
+@@ -653,16 +653,13 @@
+
+ DEF_CLIENT_RECEIVE_COMMAND(PACKET_SERVER_ERROR_QUIT)
+ {
+-	int errorno;
+ 	char str[100];
+ 	uint16 index;
+ 	NetworkClientInfo *ci;
+
+ 	index = NetworkRecv_uint16(MY_CLIENT, p);
+-	errorno = NetworkRecv_uint8(MY_CLIENT, p);
++	GetNetworkErrorMsg(str, NetworkRecv_uint8(MY_CLIENT, p));
+
+-	GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + errorno);
+-
+ 	ci = NetworkFindClientInfoFromIndex(index);
+ 	if (ci != NULL) {
+ 		NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, ci->client_name, str);
+Index: network_server.c
+===================================================================
+--- network_server.c	(revision 19646)
++++ network_server.c	(working copy)
+@@ -24,8 +24,6 @@
+
+ extern const char _openttd_revision[];
+
+-// Is the network enabled?
+-
+ // **********
+ // Sending functions
+ //   DEF_SERVER_SEND_COMMAND has parameter: NetworkClientState *cs
+@@ -155,7 +153,7 @@
+ 	if (cs->status > STATUS_AUTH) {
+ 		NetworkGetClientName(client_name, sizeof(client_name), cs);
+
+-		GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + error);
++		GetNetworkErrorMsg(str, error);
+
+ 		DEBUG(net, 2)("[NET] %s made an error (%s) and his connection is closed", client_name, str);
+
+@@ -891,8 +889,8 @@
+ 	// This packets means a client noticed an error and is reporting this
+ 	//  to us. Display the error and report it to the other clients
+ 	NetworkClientState *new_cs;
+-	byte errorno = NetworkRecv_uint8(cs, p);
+ 	char str[100];
++	NetworkErrorCode errorno = NetworkRecv_uint8(cs, p);
+ 	char client_name[NETWORK_CLIENT_NAME_LENGTH];
+
+ 	// The client was never joined.. thank the client for the packet, but ignore it
+@@ -903,7 +901,7 @@
+
+ 	NetworkGetClientName(client_name, sizeof(client_name), cs);
+
+-	GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + errorno);
++	GetNetworkErrorMsg(str, errorno);
+
+ 	DEBUG(net, 2)("[NET] %s reported an error and is closing his connection (%s)", client_name, str);
+

--- a/_security/CVE-2006-1998/0.4.5 - 0.4.7.patch
+++ b/_security/CVE-2006-1998/0.4.5 - 0.4.7.patch
@@ -1,0 +1,131 @@
+---
+layout: security_patch
+cve: CVE-2006-1998
+first_version: 0.4.5
+last_version: 0.4.7
+---
+
+Index: network.c
+===================================================================
+--- network.c
++++ network.c
+@@ -256,6 +256,36 @@
+ 	_networking = false;
+ }
+
++/** Retrieve a string representation of an internal error number
++ * @param buf buffer where the error message will be stored
++ * @param err NetworkErrorCode (integer)
++ * @return returns a pointer to the error message (buf) */
++char *GetNetworkErrorMsg(char *buf, NetworkErrorCode err)
++{
++	/* List of possible network errors, used by
++	 * PACKET_SERVER_ERROR and PACKET_CLIENT_ERROR */
++	static const StringID network_error_strings[] = {
++		STR_NETWORK_ERR_CLIENT_GENERAL,
++		STR_NETWORK_ERR_CLIENT_DESYNC,
++		STR_NETWORK_ERR_CLIENT_SAVEGAME,
++		STR_NETWORK_ERR_CLIENT_CONNECTION_LOST,
++		STR_NETWORK_ERR_CLIENT_PROTOCOL_ERROR,
++		STR_NETWORK_ERR_CLIENT_NOT_AUTHORIZED,
++		STR_NETWORK_ERR_CLIENT_NOT_EXPECTED,
++		STR_NETWORK_ERR_CLIENT_WRONG_REVISION,
++		STR_NETWORK_ERR_CLIENT_NAME_IN_USE,
++		STR_NETWORK_ERR_CLIENT_WRONG_PASSWORD,
++		STR_NETWORK_ERR_CLIENT_PLAYER_MISMATCH,
++		STR_NETWORK_ERR_CLIENT_KICKED,
++		STR_NETWORK_ERR_CLIENT_CHEATER,
++		STR_NETWORK_ERR_CLIENT_SERVER_FULL,
++	};
++
++	if (err >= lengthof(network_error_strings)) err = 0;
++
++	return GetString(buf, network_error_strings[err]);
++}
++
+ // Find all IP-aliases for this host
+ static void NetworkFindIPs(void)
+ {
+@@ -524,7 +554,7 @@
+
+ 		NetworkGetClientName(client_name, sizeof(client_name), cs);
+
+-		GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + errorno);
++		GetNetworkErrorMsg(str, errorno);
+
+ 		NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, client_name, "%s", str);
+
+Index: network_data.h
+===================================================================
+--- network_data.h
++++ network_data.h
+@@ -230,6 +230,7 @@
+ NetworkClientInfo *NetworkFindClientInfoFromIP(const char *ip);
+ NetworkClientState *NetworkFindClientStateFromIndex(uint16 client_index);
+ unsigned long NetworkResolveHost(const char *hostname);
++char *GetNetworkErrorMsg(char *buf, NetworkErrorCode err);
+
+ #endif /* ENABLE_NETWORK */
+
+Index: network_client.c
+===================================================================
+--- network_client.c
++++ network_client.c
+@@ -683,16 +683,13 @@
+
+ DEF_CLIENT_RECEIVE_COMMAND(PACKET_SERVER_ERROR_QUIT)
+ {
+-	int errorno;
+ 	char str[100];
+ 	uint16 index;
+ 	NetworkClientInfo *ci;
+
+ 	index = NetworkRecv_uint16(MY_CLIENT, p);
+-	errorno = NetworkRecv_uint8(MY_CLIENT, p);
++	GetNetworkErrorMsg(str, NetworkRecv_uint8(MY_CLIENT, p));
+
+-	GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + errorno);
+-
+ 	ci = NetworkFindClientInfoFromIndex(index);
+ 	if (ci != NULL) {
+ 		NetworkTextMessage(NETWORK_ACTION_LEAVE, 1, false, ci->client_name, "%s", str);
+Index: network_server.c
+===================================================================
+--- network_server.c
++++ network_server.c
+@@ -29,8 +29,6 @@
+
+ void NetworkPopulateCompanyInfo(void);
+
+-// Is the network enabled?
+-
+ // **********
+ // Sending functions
+ //   DEF_SERVER_SEND_COMMAND has parameter: NetworkClientState *cs
+@@ -148,7 +146,7 @@
+ 	NetworkSend_uint8(p, error);
+ 	NetworkSend_Packet(p, cs);
+
+-	GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + error);
++	GetNetworkErrorMsg(str, error);
+
+ 	// Only send when the current client was in game
+ 	if (cs->status > STATUS_AUTH) {
+@@ -890,8 +889,8 @@
+ 	// This packets means a client noticed an error and is reporting this
+ 	//  to us. Display the error and report it to the other clients
+ 	NetworkClientState *new_cs;
+-	byte errorno = NetworkRecv_uint8(cs, p);
+ 	char str[100];
++	NetworkErrorCode errorno = NetworkRecv_uint8(cs, p);
+ 	char client_name[NETWORK_CLIENT_NAME_LENGTH];
+
+ 	// The client was never joined.. thank the client for the packet, but ignore it
+@@ -902,7 +901,7 @@
+
+ 	NetworkGetClientName(client_name, sizeof(client_name), cs);
+
+-	GetString(str, STR_NETWORK_ERR_CLIENT_GENERAL + errorno);
++	GetNetworkErrorMsg(str, errorno);
+
+ 	DEBUG(net, 2)("[NET] %s reported an error and is closing his connection (%s)", client_name, str);

--- a/_security/CVE-2006-1999.md
+++ b/_security/CVE-2006-1999.md
@@ -1,0 +1,24 @@
+---
+name: CVE-2006-1999
+description: Denial of service (client) via UDP packet with incorrect size
+first_vulnerable: 0.3.5
+first_fixed: 0.4.8
+related_bugs: []
+related_commits:
+- 4a4b860
+patches:
+- name: For version 0.3.5 up to including 0.4.7
+  file: 0.3.5 - 0.4.7.patch
+---
+
+Clients are affected by an harmless bug when they handle UDP packets.
+The first 2 bytes of each UDP packet are a 16 bit number which
+specifies the size of the packet.
+If this value in a received packet is invalid (for example too small)
+the client returns immediately to the main menu.
+This bug becomes problematic when a malicious server visible in the
+master server list sends invalid replies to the queries sent from the
+clients which want to play online and will be no longer able to do it
+due to the returning to the main menu.
+
+Note that this is a partial backport of trunk r4413.

--- a/_security/CVE-2006-1999/0.3.5 - 0.4.7.patch
+++ b/_security/CVE-2006-1999/0.3.5 - 0.4.7.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2006-1999
+first_version: 0.3.5
+last_version: 0.4.7
+---
+
+Index: network_data.c
+===================================================================
+--- network_data.c
++++ network_data.c
+@@ -125,7 +125,7 @@
+ 	NetworkCloseClient(cs);
+
+ 	// Clients drop back to the main menu
+-	if (!_network_server) {
++	if (!_network_server && _networking) {
+ 		_switch_mode = SM_MENU;
+ 		_networking = false;
+ 		_switch_mode_errorstr = STR_NETWORK_ERR_LOSTCONNECTION;

--- a/_security/CVE-2008-3547.md
+++ b/_security/CVE-2008-3547.md
@@ -1,0 +1,30 @@
+---
+name: CVE-2008-3547
+description: Denial of service (server) via UDP request
+first_vulnerable: 0.3.5
+first_fixed: 0.6.2
+related_bugs: []
+related_commits:
+- 60a6582
+patches:
+- name: For version 0.3.5 up to including 0.5.3
+  file: 0.3.5 - 0.5.3.patch
+- name: For version 0.6.0 up to including 0.6.1
+  file: 0.6.0 - 0.6.1.patch
+---
+
+Buffer overflow in the server requiring remote authenticated users to set long
+names for companies and clients before a non-authenticated user can trigger a
+buffer overflow and possibly execute arbitrary code.
+
+The buffer overflow is triggered while creating a packet that is never
+requested by normal clients and was only added to facilitate external
+applications to query the clients and companies on a server. The solution
+(trunk r13713) applied in 0.6.2 and later implements a new version of that
+protocol that is not vulnerable, however not returning anything at all would
+prevent this bug from being triggered while still being technically correct as
+the bug happens creating an UDP packet and those are not guaranteed to be
+delivered.
+
+The attached patch disables this creating and thus sending the package
+completely.

--- a/_security/CVE-2008-3547/0.3.5 - 0.5.3.patch
+++ b/_security/CVE-2008-3547/0.3.5 - 0.5.3.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2008-3547
+first_version: 0.3.5
+last_version: 0.5.3
+---
+
+Index: network_udp.c
+===================================================================
+--- network_udp.c
++++ network_udp.c
+@@ -97,6 +97,8 @@
+ 	Player *player;
+ 	byte current = 0;
+ 	int i;
++
++	return; // prevent CVE-2008-3547 from happening
+
+ 	// Just a fail-safe.. should never happen
+ 	if (!_network_udp_server) return;

--- a/_security/CVE-2008-3547/0.6.0 - 0.6.1.patch
+++ b/_security/CVE-2008-3547/0.6.0 - 0.6.1.patch
@@ -1,0 +1,21 @@
+---
+layout: security_patch
+cve: CVE-2008-3547
+first_version: 0.6.0
+last_version: 0.6.1
+---
+
+Index: src/network/network_udp.cpp
+===================================================================
+--- src/network/network_udp.cpp
++++ src/network/network_udp.cpp
+@@ -97,6 +97,8 @@
+ 	Player *player;
+ 	byte current = 0;
+ 	int i;
++
++	return; // prevent CVE-2008-3547 from happening
+
+ 	// Just a fail-safe.. should never happen
+ 	if (!_network_udp_server) return;
+

--- a/_security/CVE-2008-3576.md
+++ b/_security/CVE-2008-3576.md
@@ -1,0 +1,24 @@
+---
+name: CVE-2008-3576
+description: Buffer overflow in string truncation.
+first_vulnerable: 0.4.5
+first_fixed: 0.6.2
+related_bugs: []
+related_commits:
+- 71820bf
+patches:
+- name: For version 0.4.5 up to including 0.4.8
+  file: 0.4.5 - 0.4.8.patch
+- name: For version 0.5.0 up to including 0.5.3
+  file: 0.5.0 - 0.5.3.patch
+- name: For version 0.6.0 up to including 0.6.1
+  file: 0.6.0 - 0.6.1.patch
+---
+
+Buffer overflow in the TruncateString function allows remote attackers to cause
+a denial of service (daemon crash) or possibly execute arbitrary code via a
+crafted string.
+
+To trigger this bug a custom language file is needed that is large enough to
+exceed the size of the buffer. No released version of OpenTTD has had strings
+nearly long enough to trigger this.

--- a/_security/CVE-2008-3576/0.4.5 - 0.4.8.patch
+++ b/_security/CVE-2008-3576/0.4.5 - 0.4.8.patch
@@ -1,0 +1,25 @@
+---
+layout: security_patch
+cve: CVE-2008-3576
+first_version: 0.4.5
+last_version: 0.4.8
+---
+
+Index: gfx.c
+===================================================================
+--- gfx.c
++++ gfx.c
+@@ -256,9 +256,10 @@
+ 			w += GetCharacterWidth(size, c);
+
+ 			if (w >= maxw) {
+-				// string got too big... insert dotdotdot
+-				ddd_pos[0] = ddd_pos[1] = ddd_pos[2] = '.';
+-				ddd_pos[3] = 0;
++				/* string got too big... insert dotdotdot, but make sure we do not
++				 * print anything beyond the string termination character. */
++				for (int i = 0; *ddd_pos != '\0' && i < 3; i++, ddd_pos++) *ddd_pos = '.';
++				*ddd_pos = '\0';
+ 				return ddd_w;
+ 			}
+ 		} else {

--- a/_security/CVE-2008-3576/0.5.0 - 0.5.3.patch
+++ b/_security/CVE-2008-3576/0.5.0 - 0.5.3.patch
@@ -1,0 +1,25 @@
+---
+layout: security_patch
+cve: CVE-2008-3576
+first_version: 0.5.0
+last_version: 0.5.3
+---
+
+Index: gfx.c
+===================================================================
+--- gfx.c
++++ gfx.c
+@@ -256,9 +256,10 @@
+ 			w += GetCharacterWidth(size, c);
+
+ 			if (w >= maxw) {
+-				// string got too big... insert dotdotdot
+-				ddd_pos[0] = ddd_pos[1] = ddd_pos[2] = '.';
+-				ddd_pos[3] = '\0';
++				/* string got too big... insert dotdotdot, but make sure we do not
++				 * print anything beyond the string termination character. */
++				for (int i = 0; *ddd_pos != '\0' && i < 3; i++, ddd_pos++) *ddd_pos = '.';
++				*ddd_pos = '\0';
+ 				return ddd_w;
+ 			}
+ 		} else {

--- a/_security/CVE-2008-3576/0.6.0 - 0.6.1.patch
+++ b/_security/CVE-2008-3576/0.6.0 - 0.6.1.patch
@@ -1,0 +1,26 @@
+---
+layout: security_patch
+cve: CVE-2008-3576
+first_version: 0.6.0
+last_version: 0.6.1
+---
+
+Index: src/gfx.cpp
+===================================================================
+--- src/gfx.cpp
++++ src/gfx.cpp
+@@ -256,9 +256,10 @@
+ 			w += GetCharacterWidth(size, c);
+
+ 			if (w >= maxw) {
+-				/* string got too big... insert dotdotdot */
+-				ddd_pos[0] = ddd_pos[1] = ddd_pos[2] = '.';
+-				ddd_pos[3] = '\0';
++				/* string got too big... insert dotdotdot, but make sure we do not
++				 * print anything beyond the string termination character. */
++				for (int i = 0; *ddd_pos != '\0' && i < 3; i++, ddd_pos++) *ddd_pos = '.';
++				*ddd_pos = '\0';
+ 				return ddd_w;
+ 			}
+ 		} else {
+

--- a/_security/CVE-2008-3577.md
+++ b/_security/CVE-2008-3577.md
@@ -1,0 +1,24 @@
+---
+name: CVE-2008-3577
+description: Buffer overflow in "-g" parameter handling
+first_vulnerable: 0.1.0
+first_fixed: 0.6.2
+related_bugs: []
+related_commits:
+- 6860193
+patches:
+- name: For version 0.1.0 up to including 0.3.3
+  file: 0.1.0 - 0.3.3.patch
+- name: For version 0.3.4 up to including 0.4.0.1
+  file: 0.3.4 - 0.4.0.1.patch
+- name: For version 0.4.5 up to including 0.5.3
+  file: 0.4.5 - 0.5.3.patch
+- name: For version 0.6.0 up to including 0.6.1
+  file: 0.6.0 - 0.6.1.patch
+---
+
+Buffer overflow allowing local users to possibly execute arbitrary code via a
+large filename supplied to the "-g" parameter in the ttd_main function.
+
+NOTE: it is unlikely that this issue would cross privilege boundaries in
+typical environments.

--- a/_security/CVE-2008-3577/0.1.0 - 0.3.3.patch
+++ b/_security/CVE-2008-3577/0.1.0 - 0.3.3.patch
@@ -1,0 +1,19 @@
+---
+layout: security_patch
+cve: CVE-2008-3577
+first_version: 0.1.0
+last_version: 0.3.3
+---
+
+Index: ttd.c
+===================================================================
+--- ttd.c
++++ ttd.c
+@@ -458,6 +458,6 @@
+ 		case 'g':
+ 			if (mgo.opt) {
+-				strcpy(_file_to_saveload, mgo.opt);
++				ttd_strlcpy(_file_to_saveload, mgo.opt, sizeof(_file_to_saveload));
+ 				_switch_mode = SM_LOAD;
+ 			} else {
+ 				_switch_mode = SM_NEWGAME;

--- a/_security/CVE-2008-3577/0.3.4 - 0.4.0.1.patch
+++ b/_security/CVE-2008-3577/0.3.4 - 0.4.0.1.patch
@@ -1,0 +1,19 @@
+---
+layout: security_patch
+cve: CVE-2008-3577
+first_version: 0.3.4
+last_version: 0.4.0.1
+---
+
+Index: ttd.c
+===================================================================
+--- ttd.c
++++ ttd.c
+@@ -458,6 +458,6 @@
+ 		case 'g':
+ 			if (mgo.opt) {
+-				strcpy(_file_to_saveload.name, mgo.opt);
++				ttd_strlcpy(_file_to_saveload.name, mgo.opt, sizeof(_file_to_saveload.name));
+ 				_switch_mode = SM_LOAD;
+ 			} else {
+ 				_switch_mode = SM_NEWGAME;

--- a/_security/CVE-2008-3577/0.4.5 - 0.5.3.patch
+++ b/_security/CVE-2008-3577/0.4.5 - 0.5.3.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2008-3577
+first_version: 0.4.5
+last_version: 0.5.3
+---
+
+Index: openttd.c
+===================================================================
+--- openttd.c
++++ openttd.c
+@@ -458,7 +458,7 @@
+ 		case 'i': _use_dos_palette = true; break;
+ 		case 'g':
+ 			if (mgo.opt != NULL) {
+-				strcpy(_file_to_saveload.name, mgo.opt);
++				ttd_strlcpy(_file_to_saveload.name, mgo.opt, sizeof(_file_to_saveload.name));
+ 				_switch_mode = SM_LOAD;
+ 			} else {
+ 				_switch_mode = SM_NEWGAME;

--- a/_security/CVE-2008-3577/0.6.0 - 0.6.1.patch
+++ b/_security/CVE-2008-3577/0.6.0 - 0.6.1.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2008-3577
+first_version: 0.6.0
+last_version: 0.6.1
+---
+
+Index: src/openttd.cpp
+===================================================================
+--- src/openttd.cpp
++++ src/openttd.cpp
+@@ -458,7 +458,7 @@
+ 		case 'i': _use_dos_palette = true; break;
+ 		case 'g':
+ 			if (mgo.opt != NULL) {
+-				strcpy(_file_to_saveload.name, mgo.opt);
++				ttd_strlcpy(_file_to_saveload.name, mgo.opt, sizeof(_file_to_saveload.name));
+ 				_switch_mode = SM_LOAD;
+ 			} else {
+ 				_switch_mode = SM_NEWGAME;

--- a/_security/CVE-2009-4007.md
+++ b/_security/CVE-2009-4007.md
@@ -1,0 +1,49 @@
+---
+name: CVE-2009-4007
+description: Denial of service (server) using wagons and dual-headed engine
+first_vulnerable: 0.6.0
+first_fixed: 0.7.5
+related_bugs: []
+related_commits:
+- b8a7efc
+patches:
+- name: For version 0.6.0 up to including 0.7.4
+  file: 0.6.0 - 0.7.4.patch
+---
+
+Denial of service using wagons and dual headed wagons.
+
+Simple steps to reproduce the issue, and show the severity:
+1. start a new game in the year 1960; note that this crash works with all dual
+   headed trains and as such basically all servers with a game date after about
+   the year 1960. For this reproduction you do not need to start a server; you
+   can see the crash locally, but due to the nature of OpenTTD the crash will
+   also happen on the server you're playing on with multiplayer.
+1. build a rail depot
+1. open the depot window
+1. buy two dual headed trains, the Manley-Morel DMU (Diesel)
+1. buy two wagons, e.g. passenger wagons
+1. move train 2 to the back of the unnumbered train at line 3, the unnumbered
+   train goes to line 2 now
+1. move the second wagon of the unnumbered train to be placed at the third
+   position, i.e. between the two dualhead parts
+1. move, while pressing Ctrl (this is important), the second wagon on third
+   position of the unnumbered train to the back of train 1
+1. sell the complete unnumbered train, while pressing Ctrl drag it to the top
+   button on the right and this will then trigger a segmentation fault
+
+
+The problem is caused by the fact that the free wagon chains aren't normalised,
+i.e. the dualheads aren't properly put together. It is trivially fixed by
+running the normalisation of the train also over free wagon chains. As
+NormaliseTrainConsist is only ran on the front of trains v may only be
+IsFreeWagon or IsFrontEngine, which is what the assert tests, but as the assert
+isn't executed for release builds it can be removed instead of updated to cover
+both IsFrontEngine and IsFreeWagon.
+
+If you try to reproduce this with the patch applied you'll see that after step
+8 only the wagon is moved and not the half of the dual headed train. This will
+then make sure you cannot sell only one part of the dual headed train, which is
+what causes the segmentation fault.
+
+We have not seen any signs of this bug being exploited in the real world.

--- a/_security/CVE-2009-4007/0.6.0 - 0.7.4.patch
+++ b/_security/CVE-2009-4007/0.6.0 - 0.7.4.patch
@@ -1,0 +1,24 @@
+---
+layout: security_patch
+cve: CVE-2009-4007
+first_version: 0.6.0
+last_version: 0.7.4
+---
+
+Index: src/train_cmd.cpp
+===================================================================
+--- src/train_cmd.cpp
++++ src/train_cmd.cpp
+@@ -996,10 +996,6 @@
+  */
+ static void NormaliseTrainConsist(Vehicle *v)
+ {
+-	if (IsFreeWagon(v)) return;
+-
+-	assert(IsFrontEngine(v));
+-
+ 	for (; v != NULL; v = GetNextVehicle(v)) {
+ 		if (!IsMultiheaded(v) || !IsTrainEngine(v)) continue;
+
+
+

--- a/_security/CVE-2010-0401.md
+++ b/_security/CVE-2010-0401.md
@@ -1,0 +1,42 @@
+---
+name: CVE-2010-0401
+description: Access restriction circumvention, remote crash
+first_vulnerable: 0.3.5
+first_fixed: 1.0.1
+related_bugs:
+- 3754
+related_commits:
+- 11d6e21
+- df4d8b3
+patches:
+- name: For version 0.7.0 up to including 1.0.0
+  file: 0.7.0 - 1.0.0.patch
+- name: For version 0.6.0 up to including 0.6.3
+  file: 0.6.0 - 0.6.3.patch
+- name: For version 0.5.1 up to including 0.5.3
+  file: 0.5.1 - 0.5.3.patch
+- name: For version 0.3.5 up to including 0.5.0
+  file: 0.3.5 - 0.5.0.patch
+---
+
+It is possible to circumvent the server password of a network game. It is
+possible in two cases:
+  1.you know the company password of one of the companies
+  1.one of the companies has no password
+
+In both cases you send the company password (or "" if there is none) when you
+receive the request for the server's password.
+
+This fix also prevents reading invalid data and possibly crashing a server when
+a spectator sends a company password packet. Even though this is technically
+a different vulnerability, the fix for the access restriction circumvention fixes
+the other vulnerability too as it will never request and thus accept company
+password packets from spectators.
+
+Note that this is a custom fix for backports as a more elobarate fix with a
+different network protocol was used for 1.0.1 and trunk (r19607). However,
+we cannot break the network protocol for older versions thus this version is
+needed.
+This version does not change the network protocol, except for a
+misbehaving client that sends the company password if the server password is
+expected. In this case the client is disconnected citing a protocol error.

--- a/_security/CVE-2010-0401/0.3.5 - 0.5.0.patch
+++ b/_security/CVE-2010-0401/0.3.5 - 0.5.0.patch
@@ -1,0 +1,78 @@
+---
+layout: security_patch
+cve: CVE-2010-0401
+first_version: 0.3.5
+last_version: 0.5.0
+---
+
+Index: network_data.h
+===================================================================
+--- network_data.h	(revision 19680)
++++ network_data.h	(working copy)
+@@ -47,12 +47,15 @@
+
+ typedef enum {
+ 	STATUS_INACTIVE,
++	STATUS_AUTH_GAME,    ///< The client is authorizing with game (server) password
++	STATUS_AUTH_COMPANY, ///< The client is authorizing with company password
+ 	STATUS_AUTH, // This means that the client is authorized
+ 	STATUS_MAP_WAIT, // This means that the client is put on hold because someone else is getting the map
+ 	STATUS_MAP,
+ 	STATUS_DONE_MAP,
+ 	STATUS_PRE_ACTIVE,
+ 	STATUS_ACTIVE,
++	STATUS_END
+ } ClientStatus;
+
+ typedef enum {
+Index: console_cmds.c
+===================================================================
+--- console_cmds.c	(revision 19680)
++++ console_cmds.c	(working copy)
+@@ -512,7 +512,7 @@
+
+ DEF_CONSOLE_CMD(ConStatus)
+ {
+-	static const char *stat_str[] = {"inactive", "authorized", "waiting", "loading map", "map done", "ready", "active"};
++	static const char *stat_str[] = {"inactive", "authorizing (server)", "authorizing (company)", "authorized", "waiting", "loading map", "map done", "ready", "active"};
+ 	const char *status;
+ 	const NetworkClientState *cs;
+
+Index: network_server.c
+===================================================================
+--- network_server.c	(revision 19680)
++++ network_server.c	(working copy)
+@@ -192,7 +192,14 @@
+ 	//    uint8:  Type of password
+ 	//
+
+-	Packet *p = NetworkSend_Init(PACKET_SERVER_NEED_PASSWORD);
++	Packet *p;
++
++	/* Invalid packet when status is AUTH or higher */
++	if (cs->status >= STATUS_AUTH) return;
++
++	cs->status = type == NETWORK_GAME_PASSWORD ? STATUS_AUTH_GAME : STATUS_AUTH_COMPANY;
++
++	p = NetworkSend_Init(PACKET_SERVER_NEED_PASSWORD);
+ 	NetworkSend_uint8(p, type);
+ 	NetworkSend_Packet(p, cs);
+ }
+@@ -662,7 +669,7 @@
+ 	type = NetworkRecv_uint8(cs, p);
+ 	NetworkRecv_string(cs, p, password, sizeof(password));
+
+-	if (cs->status == STATUS_INACTIVE && type == NETWORK_GAME_PASSWORD) {
++	if (cs->status == STATUS_AUTH_GAME && type == NETWORK_GAME_PASSWORD) {
+ 		// Check game-password
+ 		if (strncmp(password, _network_game_info.server_password, sizeof(password)) != 0) {
+ 			// Password is invalid
+@@ -680,7 +687,7 @@
+ 		// Valid password, allow user
+ 		SEND_COMMAND(PACKET_SERVER_WELCOME)(cs);
+ 		return;
+-	} else if (cs->status == STATUS_INACTIVE && type == NETWORK_COMPANY_PASSWORD) {
++	} else if (cs->status == STATUS_AUTH_COMPANY && type == NETWORK_COMPANY_PASSWORD) {
+ 		ci = DEREF_CLIENT_INFO(cs);
+
+ 		if (strncmp(password, _network_player_info[ci->client_playas - 1].password, sizeof(password)) != 0) {

--- a/_security/CVE-2010-0401/0.5.1 - 0.5.3.patch
+++ b/_security/CVE-2010-0401/0.5.1 - 0.5.3.patch
@@ -1,0 +1,73 @@
+---
+layout: security_patch
+cve: CVE-2010-0401
+first_version: 0.5.1
+last_version: 0.5.3
+---
+
+Index: network_data.h
+===================================================================
+--- network_data.h	(revision 19680)
++++ network_data.h	(working copy)
+@@ -49,13 +49,15 @@
+
+ typedef enum {
+ 	STATUS_INACTIVE,
+-	STATUS_AUTHORIZING, // This means that the client is authorizing
++	STATUS_AUTH_GAME,    ///< The client is authorizing with game (server) password
++	STATUS_AUTH_COMPANY, ///< The client is authorizing with company password
+ 	STATUS_AUTH, // This means that the client is authorized
+ 	STATUS_MAP_WAIT, // This means that the client is put on hold because someone else is getting the map
+ 	STATUS_MAP,
+ 	STATUS_DONE_MAP,
+ 	STATUS_PRE_ACTIVE,
+ 	STATUS_ACTIVE,
++	STATUS_END         ///< Must ALWAYS be on the end of this list!! (period)
+ } ClientStatus;
+
+ typedef enum {
+Index: console_cmds.c
+===================================================================
+--- console_cmds.c	(revision 19680)
++++ console_cmds.c	(working copy)
+@@ -529,7 +529,8 @@
+ {
+ 	static const char* const stat_str[] = {
+ 		"inactive",
+-		"authorizing",
++		"authorizing (server password)",
++		"authorizing (company password)",
+ 		"authorized",
+ 		"waiting",
+ 		"loading map",
+Index: network_server.c
+===================================================================
+--- network_server.c	(revision 19680)
++++ network_server.c	(working copy)
+@@ -220,7 +220,7 @@
+ 	/* Invalid packet when status is AUTH or higher */
+ 	if (cs->status >= STATUS_AUTH) return;
+
+-	cs->status = STATUS_AUTHORIZING;
++	cs->status = type == NETWORK_GAME_PASSWORD ? STATUS_AUTH_GAME : STATUS_AUTH_COMPANY;
+
+ 	p = NetworkSend_Init(PACKET_SERVER_NEED_PASSWORD);
+ 	NetworkSend_uint8(p, type);
+@@ -701,7 +701,7 @@
+ 	type = NetworkRecv_uint8(cs, p);
+ 	NetworkRecv_string(cs, p, password, sizeof(password));
+
+-	if (cs->status == STATUS_AUTHORIZING && type == NETWORK_GAME_PASSWORD) {
++	if (cs->status == STATUS_AUTH_GAME && type == NETWORK_GAME_PASSWORD) {
+ 		// Check game-password
+ 		if (strcmp(password, _network_game_info.server_password) != 0) {
+ 			// Password is invalid
+@@ -719,7 +719,7 @@
+ 		// Valid password, allow user
+ 		SEND_COMMAND(PACKET_SERVER_WELCOME)(cs);
+ 		return;
+-	} else if (cs->status == STATUS_AUTHORIZING && type == NETWORK_COMPANY_PASSWORD) {
++	} else if (cs->status == STATUS_AUTH_COMPANY && type == NETWORK_COMPANY_PASSWORD) {
+ 		ci = DEREF_CLIENT_INFO(cs);
+
+ 		if (strcmp(password, _network_player_info[ci->client_playas].password) != 0) {

--- a/_security/CVE-2010-0401/0.6.0 - 0.6.3.patch
+++ b/_security/CVE-2010-0401/0.6.0 - 0.6.3.patch
@@ -1,0 +1,73 @@
+---
+layout: security_patch
+cve: CVE-2010-0401
+first_version: 0.6.0
+last_version: 0.6.3
+---
+
+Index: src/console_cmds.cpp
+===================================================================
+--- src/console_cmds.cpp	(revision 19680)
++++ src/console_cmds.cpp	(working copy)
+@@ -549,7 +549,8 @@
+ {
+ 	static const char* const stat_str[] = {
+ 		"inactive",
+-		"authorizing",
++		"authorizing (server password)",
++		"authorizing (company password)",
+ 		"authorized",
+ 		"waiting",
+ 		"loading map",
+Index: src/network/core/tcp.h
+===================================================================
+--- src/network/core/tcp.h	(revision 19680)
++++ src/network/core/tcp.h	(working copy)
+@@ -75,13 +75,15 @@
+ /** Status of a client */
+ enum ClientStatus {
+ 	STATUS_INACTIVE,   ///< The client is not connected nor active
+-	STATUS_AUTHORIZING,///< The client is authorizing
++	STATUS_AUTH_GAME,  ///< The client is authorizing with game (server) password
++	STATUS_AUTH_COMPANY, ///< The client is authorizing with company password
+ 	STATUS_AUTH,       ///< The client is authorized
+ 	STATUS_MAP_WAIT,   ///< The client is waiting as someone else is downloading the map
+ 	STATUS_MAP,        ///< The client is downloading the map
+ 	STATUS_DONE_MAP,   ///< The client has downloaded the map
+ 	STATUS_PRE_ACTIVE, ///< The client is catching up the delayed frames
+ 	STATUS_ACTIVE,     ///< The client is an active player in the game
++	STATUS_END         ///< Must ALWAYS be on the end of this list!! (period)
+ };
+
+ /** Base socket handler for all TCP sockets */
+Index: src/network/network_server.cpp
+===================================================================
+--- src/network/network_server.cpp	(revision 19680)
++++ src/network/network_server.cpp	(working copy)
+@@ -221,7 +221,7 @@
+ 	/* Invalid packet when status is AUTH or higher */
+ 	if (cs->status >= STATUS_AUTH) return;
+
+-	cs->status = STATUS_AUTHORIZING;
++	cs->status = type == NETWORK_GAME_PASSWORD ? STATUS_AUTH_GAME : STATUS_AUTH_COMPANY;
+
+ 	Packet *p = NetworkSend_Init(PACKET_SERVER_NEED_PASSWORD);
+ 	p->Send_uint8(type);
+@@ -715,7 +715,7 @@
+ 	type = (NetworkPasswordType)p->Recv_uint8();
+ 	p->Recv_string(password, sizeof(password));
+
+-	if (cs->status == STATUS_AUTHORIZING && type == NETWORK_GAME_PASSWORD) {
++	if (cs->status == STATUS_AUTH_GAME && type == NETWORK_GAME_PASSWORD) {
+ 		// Check game-password
+ 		if (strcmp(password, _network_game_info.server_password) != 0) {
+ 			// Password is invalid
+@@ -733,7 +733,7 @@
+ 		// Valid password, allow user
+ 		SEND_COMMAND(PACKET_SERVER_WELCOME)(cs);
+ 		return;
+-	} else if (cs->status == STATUS_AUTHORIZING && type == NETWORK_COMPANY_PASSWORD) {
++	} else if (cs->status == STATUS_AUTH_COMPANY && type == NETWORK_COMPANY_PASSWORD) {
+ 		ci = DEREF_CLIENT_INFO(cs);
+
+ 		if (strcmp(password, _network_player_info[ci->client_playas].password) != 0) {

--- a/_security/CVE-2010-0401/0.7.0 - 1.0.0.patch
+++ b/_security/CVE-2010-0401/0.7.0 - 1.0.0.patch
@@ -1,0 +1,77 @@
+---
+layout: security_patch
+cve: CVE-2010-0401
+first_version: 0.7.0
+last_version: 1.0.0
+---
+
+Index: src/network/core/tcp_game.h
+===================================================================
+--- src/network/core/tcp_game.h	(revision 19678)
++++ src/network/core/tcp_game.h	(working copy)
+@@ -67,13 +67,15 @@
+ /** Status of a client */
+ enum ClientStatus {
+ 	STATUS_INACTIVE,   ///< The client is not connected nor active
+-	STATUS_AUTHORIZING,///< The client is authorizing
++	STATUS_AUTH_GAME,  ///< The client is authorizing with game (server) password
++	STATUS_AUTH_COMPANY, ///< The client is authorizing with company password
+ 	STATUS_AUTH,       ///< The client is authorized
+ 	STATUS_MAP_WAIT,   ///< The client is waiting as someone else is downloading the map
+ 	STATUS_MAP,        ///< The client is downloading the map
+ 	STATUS_DONE_MAP,   ///< The client has downloaded the map
+ 	STATUS_PRE_ACTIVE, ///< The client is catching up the delayed frames
+ 	STATUS_ACTIVE,     ///< The client is active within in the game
++	STATUS_END         ///< Must ALWAYS be on the end of this list!! (period)
+ };
+
+
+Index: src/network/network_server.cpp
+===================================================================
+--- src/network/network_server.cpp	(revision 19678)
++++ src/network/network_server.cpp	(working copy)
+@@ -215,7 +215,7 @@
+ 	/* Invalid packet when status is AUTH or higher */
+ 	if (cs->status >= STATUS_AUTH) return;
+
+-	cs->status = STATUS_AUTHORIZING;
++	cs->status = type == NETWORK_GAME_PASSWORD ? STATUS_AUTH_GAME : STATUS_AUTH_COMPANY;
+
+ 	Packet *p = NetworkSend_Init(PACKET_SERVER_NEED_PASSWORD);
+ 	p->Send_uint8(type);
+@@ -727,7 +727,7 @@
+ 	type = (NetworkPasswordType)p->Recv_uint8();
+ 	p->Recv_string(password, sizeof(password));
+
+-	if (cs->status == STATUS_AUTHORIZING && type == NETWORK_GAME_PASSWORD) {
++	if (cs->status == STATUS_AUTH_GAME && type == NETWORK_GAME_PASSWORD) {
+ 		/* Check game-password */
+ 		if (strcmp(password, _settings_client.network.server_password) != 0) {
+ 			/* Password is invalid */
+@@ -745,7 +745,7 @@
+ 		/* Valid password, allow user */
+ 		SEND_COMMAND(PACKET_SERVER_WELCOME)(cs);
+ 		return;
+-	} else if (cs->status == STATUS_AUTHORIZING && type == NETWORK_COMPANY_PASSWORD) {
++	} else if (cs->status == STATUS_AUTH_COMPANY && type == NETWORK_COMPANY_PASSWORD) {
+ 		ci = cs->GetInfo();
+
+ 		if (strcmp(password, _network_company_states[ci->client_playas].password) != 0) {
+@@ -1694,7 +1694,8 @@
+ {
+ 	static const char * const stat_str[] = {
+ 		"inactive",
+-		"authorizing",
++		"authorizing (server password)",
++		"authorizing (company password)",
+ 		"authorized",
+ 		"waiting",
+ 		"loading map",
+@@ -1702,6 +1703,7 @@
+ 		"ready",
+ 		"active"
+ 	};
++	assert_compile(lengthof(stat_str) == STATUS_END);
+
+ 	NetworkClientSocket *cs;
+ 	FOR_ALL_CLIENT_SOCKETS(cs) {

--- a/_security/CVE-2010-0402.md
+++ b/_security/CVE-2010-0402.md
@@ -1,0 +1,68 @@
+---
+name: CVE-2010-0402
+description: Denial of service via improperly validated commands
+first_vulnerable: 0.3.5
+first_fixed: 1.0.1
+related_bugs:
+- 3748
+- 3747
+related_commits:
+- 1f28e23
+- a929ab0
+- 0f65601
+- 75d4bc9
+- 2a5ddd0
+- 5ecf2f7
+- 2365a4d
+patches:
+- name: For version 1.0.0 up to including 1.0.0
+  file: 1.0.0 - 1.0.0.patch
+- name: For version 0.7.0 up to including 0.7.5
+  file: 0.7.0 - 0.7.5.patch
+- name: For version 0.6.0 up to including 0.6.3
+  file: 0.6.0 - 0.6.3.patch
+---
+
+In multiple places in-game commands are not properly validated that allow
+remote attackers to cause a denial of service (crash) and possibly execute
+arbitrary code via unspecified vectors.
+
+The bug is exploitable only in-game so the attacker must have access to
+the server: his IP must not be banned, he must know the password if it
+has been set and the server must not be full.
+
+The one root cause of this problem is a generalised "pool" system that uses
+size_t to store/access indices, but has typed validation checks to check
+indices. Some of these checks use 16 bit integers, which means that a 32 bit
+"command parameter" gets silently (by the compiler) truncated to 16 bits before
+being checked after which the 32 bit number is used to access items in the
+pool.
+
+For example item 0 exists, the pool has that one item and the command parameter
+is 65536. The validation function would be checking 0, as the high 16 bits of
+the parameter would be (silently) discarded, and as such the check returns that
+it is a valid item. This then results in trying to get item 65536 which is way
+outside of the valid range of the pool.
+
+However, it is not solely confined to pooled items; there are a few cases where
+a not-yet-validated value is used.
+
+Attached are patches for all vulnerable versions since 0.6.0. Note that this is
+in essence a partial backport of trunk r19657, r19656, r19655, r19654, r19637,
+r19633 and r19621. The "in essence" is because those patches change the whole
+handling of command parameters which is 90% changing to conform to the new
+policy or standard and 10% actually fixes the crashes. Therefor we chose to
+make one minimalistic patch for each of the stable series since 0.6 that solves
+all issues we are aware of, without ending up with a ten times larger diff with
+many unrelated unneeded changes. Also earlier releases were more vulnerable
+than the later ones due to improvements in the pool system and some rewrites.
+
+Due to the time needed for assembling these patches and because we are unaware
+of any Linux distribution shipping OpenTTD from before the 0.6 series in a
+still supported release we have not made patches for those. They are vulnerable
+though.
+
+This fix maintains network compatability of patched and unpatched OpenTTD's
+except the cases where the unpatched version would crash, but then the crash
+would be the cause of the disconnection and not that they are incompatible
+on that part of the network communication.

--- a/_security/CVE-2010-0402/0.6.0 - 0.6.3.patch
+++ b/_security/CVE-2010-0402/0.6.0 - 0.6.3.patch
@@ -1,0 +1,549 @@
+---
+layout: security_patch
+cve: CVE-2010-0402
+first_version: 0.6.0
+last_version: 0.6.3
+---
+
+Index: src/terraform_cmd.cpp
+===================================================================
+--- src/terraform_cmd.cpp	(revision 19678)
++++ src/terraform_cmd.cpp	(working copy)
+@@ -365,7 +365,7 @@
+ 	oldh = TileHeight(p1);
+
+ 	/* compute new height */
+-	h = oldh + p2;
++	h = oldh + (int8)p2;
+
+ 	/* Check range of destination height */
+ 	if (h > MAX_TILE_HEIGHT) return_cmd_error((oldh == 0) ? STR_1003_ALREADY_AT_SEA_LEVEL : STR_1004_TOO_HIGH);
+Index: src/rail_cmd.cpp
+===================================================================
+--- src/rail_cmd.cpp	(revision 19678)
++++ src/rail_cmd.cpp	(working copy)
+@@ -305,8 +305,8 @@
+ CommandCost CmdBuildSingleRail(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
+ 	Slope tileh;
+-	RailType railtype = (RailType)p1;
+-	Track track = (Track)p2;
++	RailType railtype = (RailType)GB(p1, 0, 4);
++	Track track = (Track)GB(p2, 0, 3);
+ 	TrackBits trackbit;
+ 	CommandCost cost(EXPENSES_CONSTRUCTION);
+ 	CommandCost ret;
+@@ -438,12 +438,12 @@
+  */
+ CommandCost CmdRemoveSingleRail(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
+-	Track track = (Track)p2;
++	Track track = (Track)GB(p2, 0, 3);
+ 	TrackBits trackbit;
+ 	CommandCost cost(EXPENSES_CONSTRUCTION, _price.remove_rail );
+ 	bool crossing = false;
+
+-	if (!ValParamTrackOrientation((Track)p2)) return CMD_ERROR;
++	if (!ValParamTrackOrientation(track)) return CMD_ERROR;
+ 	trackbit = TrackToTrackBits(track);
+
+ 	/* Need to read tile owner now because it may change when the rail is removed
+@@ -734,6 +734,7 @@
+ 	Slope tileh;
+
+ 	/* check railtype and valid direction for depot (0 through 3), 4 in total */
++	p1 = GB(p1, 0, 4);
+ 	if (!ValParamRailtype((RailType)p1)) return CMD_ERROR;
+
+ 	tileh = GetTileSlope(tile, NULL);
+@@ -984,10 +985,9 @@
+ 	bool semaphores = HasBit(p2, 4);
+ 	bool remove = HasBit(p2, 5);
+ 	bool autofill = HasBit(p2, 6);
+-	Trackdir trackdir = TrackToTrackdir(track);
+ 	byte signal_density = GB(p2, 24, 8);
+
+-	if (p1 >= MapSize()) return CMD_ERROR;
++	if (p1 >= MapSize() || !ValParamTrackOrientation(track)) return CMD_ERROR;
+ 	end_tile = p1;
+ 	if (signal_density == 0 || signal_density > 20) return CMD_ERROR;
+
+@@ -997,6 +997,7 @@
+ 	 * since the original amount will be too dense (shorter tracks) */
+ 	signal_density *= 2;
+
++	Trackdir trackdir = TrackToTrackdir(track);
+ 	if (CmdFailed(ValidateAutoDrag(&trackdir, tile, end_tile))) return CMD_ERROR;
+
+ 	track = TrackdirToTrack(trackdir); /* trackdir might have changed, keep track in sync */
+@@ -1178,7 +1179,7 @@
+ CommandCost CmdConvertRail(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
+ 	CommandCost cost(EXPENSES_CONSTRUCTION);
+-	RailType totype = (RailType)p2;
++	RailType totype = (RailType)GB(p2, 0, 4);
+
+ 	if (!ValParamRailtype(totype)) return CMD_ERROR;
+ 	if (p1 >= MapSize()) return CMD_ERROR;
+Index: src/group_cmd.cpp
+===================================================================
+--- src/group_cmd.cpp	(revision 19678)
++++ src/group_cmd.cpp	(working copy)
+@@ -88,7 +88,7 @@
+  */
+ CommandCost CmdCreateGroup(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
+-	VehicleType vt = (VehicleType)p1;
++	VehicleType vt = (VehicleType)GB(p1, 0, 3);
+ 	if (!IsPlayerBuildableVehicleType(vt)) return CMD_ERROR;
+
+ 	if (!Group::CanAllocateItem()) return CMD_ERROR;
+@@ -114,6 +114,7 @@
+  */
+ CommandCost CmdDeleteGroup(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidGroupID(p1)) return CMD_ERROR;
+
+ 	Group *g = GetGroup(p1);
+@@ -176,6 +177,7 @@
+  */
+ CommandCost CmdRenameGroup(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidGroupID(p1) || StrEmpty(_cmd_text)) return CMD_ERROR;
+
+ 	Group *g = GetGroup(p1);
+@@ -206,6 +208,8 @@
+  */
+ CommandCost CmdAddVehicleGroup(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
++	p1 = GB(p1, 0, 16);
++	p2 = GB(p2, 0, 16);
+ 	GroupID new_g = p1;
+
+ 	if (!IsValidVehicleID(p2) || (!IsValidGroupID(new_g) && !IsDefaultGroupID(new_g))) return CMD_ERROR;
+@@ -253,12 +257,12 @@
+  */
+ CommandCost CmdAddSharedVehicleGroup(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
+-	VehicleType type = (VehicleType)p2;
++	p1 = GB(p1, 0, 16);
++	VehicleType type = (VehicleType)GB(p2, 0, 3);
+ 	if (!IsValidGroupID(p1) || !IsPlayerBuildableVehicleType(type)) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+ 		Vehicle *v;
+-		VehicleType type = (VehicleType)p2;
+ 		GroupID id_g = p1;
+
+ 		/* Find the first front engine which belong to the group id_g
+@@ -290,7 +294,8 @@
+  */
+ CommandCost CmdRemoveAllVehiclesGroup(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
+-	VehicleType type = (VehicleType)p2;
++	p1 = GB(p1, 0, 16);
++	VehicleType type = (VehicleType)GB(p2, 0, 3);
+ 	if (!IsValidGroupID(p1) || !IsPlayerBuildableVehicleType(type)) return CMD_ERROR;
+
+ 	Group *g = GetGroup(p1);
+@@ -327,6 +332,7 @@
+  */
+ CommandCost CmdSetGroupReplaceProtection(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidGroupID(p1)) return CMD_ERROR;
+
+ 	Group *g = GetGroup(p1);
+Index: src/station_cmd.cpp
+===================================================================
+--- src/station_cmd.cpp	(revision 19678)
++++ src/station_cmd.cpp	(working copy)
+@@ -1320,6 +1320,7 @@
+  */
+ CommandCost CmdBuildRoadStop(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
++	p1 = GB(p1, 0, 2);
+ 	bool type = HasBit(p2, 0);
+ 	bool is_drive_through = HasBit(p2, 1);
+ 	bool build_over_road  = is_drive_through && IsNormalRoadTile(tile);
+@@ -2638,6 +2639,7 @@
+  */
+ CommandCost CmdRenameStation(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidStationID(p1) || StrEmpty(_cmd_text)) return CMD_ERROR;
+ 	Station *st = GetStation(p1);
+
+Index: src/ship_cmd.cpp
+===================================================================
+--- src/ship_cmd.cpp	(revision 19678)
++++ src/ship_cmd.cpp	(working copy)
+@@ -810,6 +810,7 @@
+ 	UnitID unit_num;
+ 	Engine *e;
+
++	p1 = GB(p1, 0, 16);
+ 	if (!IsEngineBuildable(p1, VEH_SHIP, _current_player)) return_cmd_error(STR_SHIP_NOT_AVAILABLE);
+
+ 	value = EstimateShipCost(p1);
+Index: src/order_cmd.cpp
+===================================================================
+--- src/order_cmd.cpp	(revision 19678)
++++ src/order_cmd.cpp	(working copy)
+@@ -173,7 +173,7 @@
+
+ 	v = GetVehicle(veh);
+
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* Check if the inserted order is to the correct destination (owner, type),
+ 	 * and has the correct flags if any */
+@@ -455,15 +455,15 @@
+ CommandCost CmdDeleteOrder(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
+ 	Vehicle *v, *u;
+-	VehicleID veh_id = p1;
+-	VehicleOrderID sel_ord = p2;
++	VehicleID veh_id = GB(p1, 0, 16);
++	VehicleOrderID sel_ord = GB(p2, 0, 8);
+ 	Order *order;
+
+ 	if (!IsValidVehicleID(veh_id)) return CMD_ERROR;
+
+ 	v = GetVehicle(veh_id);
+
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* If we did not select an order, we maybe want to de-clone the orders */
+ 	if (sel_ord >= v->num_orders)
+@@ -535,14 +535,14 @@
+ CommandCost CmdSkipToOrder(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
+ 	Vehicle *v;
+-	VehicleID veh_id = p1;
+-	VehicleOrderID sel_ord = p2;
++	VehicleID veh_id = GB(p1, 0, 16);
++	VehicleOrderID sel_ord = GB(p2, 0, 8);
+
+ 	if (!IsValidVehicleID(veh_id)) return CMD_ERROR;
+
+ 	v = GetVehicle(veh_id);
+
+-	if (!CheckOwnership(v->owner) || sel_ord == v->cur_order_index ||
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner) || sel_ord == v->cur_order_index ||
+ 			sel_ord >= v->num_orders || v->num_orders < 2) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+@@ -579,14 +579,14 @@
+  */
+ CommandCost CmdMoveOrder(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
+-	VehicleID veh = p1;
++	VehicleID veh = GB(p1, 0, 16);
+ 	VehicleOrderID moving_order = GB(p2,  0, 16);
+ 	VehicleOrderID target_order = GB(p2, 16, 16);
+
+ 	if (!IsValidVehicleID(veh)) return CMD_ERROR;
+
+ 	Vehicle *v = GetVehicle(veh);
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* Don't make senseless movements */
+ 	if (moving_order >= v->num_orders || target_order >= v->num_orders ||
+@@ -675,7 +675,7 @@
+
+ 	v = GetVehicle(veh);
+
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* Is it a valid order? */
+ 	if (sel_ord >= v->num_orders) return CMD_ERROR;
+@@ -753,7 +753,7 @@
+
+ 	dst = GetVehicle(veh_dst);
+
+-	if (!CheckOwnership(dst->owner)) return CMD_ERROR;
++	if (!dst->IsPrimaryVehicle() || !CheckOwnership(dst->owner)) return CMD_ERROR;
+
+ 	switch (p2) {
+ 		case CO_SHARE: {
+@@ -764,7 +764,7 @@
+ 			src = GetVehicle(veh_src);
+
+ 			/* Sanity checks */
+-			if (!CheckOwnership(src->owner) || dst->type != src->type || dst == src)
++			if (!src->IsPrimaryVehicle() || !CheckOwnership(src->owner) || dst->type != src->type || dst == src)
+ 				return CMD_ERROR;
+
+ 			/* Trucks can't share orders with busses (and visa versa) */
+@@ -811,7 +811,7 @@
+ 			src = GetVehicle(veh_src);
+
+ 			/* Sanity checks */
+-			if (!CheckOwnership(src->owner) || dst->type != src->type || dst == src)
++			if (!src->IsPrimaryVehicle() || !CheckOwnership(src->owner) || dst->type != src->type || dst == src)
+ 				return CMD_ERROR;
+
+ 			/* Trucks can't copy all the orders from busses (and visa versa) */
+@@ -886,11 +886,12 @@
+ 	CargoID cargo = GB(p2, 0, 8);
+ 	byte subtype  = GB(p2, 8, 8);
+
++	if (cargo >= NUM_CARGO) return CMD_ERROR;
+ 	if (!IsValidVehicleID(veh)) return CMD_ERROR;
+
+ 	v = GetVehicle(veh);
+
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	order = GetVehicleOrder(v, order_number);
+ 	if (order == NULL) return CMD_ERROR;
+@@ -1033,12 +1034,13 @@
+ 	VehicleOrderID cur_ord = GB(p2,  0, 16);
+ 	uint16 serv_int = GB(p2, 16, 16);
+
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidVehicleID(p1)) return CMD_ERROR;
+
+ 	v = GetVehicle(p1);
+
+ 	/* Check the vehicle type and ownership, and if the service interval and order are in range */
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+ 	if (serv_int != GetServiceIntervalClamped(serv_int) || cur_ord >= v->num_orders) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+Index: src/waypoint.cpp
+===================================================================
+--- src/waypoint.cpp	(revision 19678)
++++ src/waypoint.cpp	(working copy)
+@@ -364,6 +364,7 @@
+  */
+ CommandCost CmdRenameWaypoint(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
++	p1 = GB(p1, 0, 16);
+ 	Waypoint *wp;
+
+ 	if (!IsValidWaypointID(p1)) return CMD_ERROR;
+Index: src/train_cmd.cpp
+===================================================================
+--- src/train_cmd.cpp	(revision 19678)
++++ src/train_cmd.cpp	(working copy)
+@@ -765,6 +765,7 @@
+  */
+ CommandCost CmdBuildRailVehicle(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
++	p1 = GB(p1, 0, 16);
+ 	/* Check if the engine-type is valid (for the player) */
+ 	if (!IsEngineBuildable(p1, VEH_TRAIN, _current_player)) return_cmd_error(STR_RAIL_VEHICLE_NOT_AVAILABLE);
+
+Index: src/tunnelbridge_cmd.cpp
+===================================================================
+--- src/tunnelbridge_cmd.cpp	(revision 19678)
++++ src/tunnelbridge_cmd.cpp	(working copy)
+@@ -218,7 +218,7 @@
+ 			break;
+
+ 		case TRANSPORT_RAIL:
+-			railtype = (RailType)GB(p2, 8, 8);
++			railtype = (RailType)GB(p2, 8, 4);
+ 			if (!ValParamRailtype(railtype)) return CMD_ERROR;
+ 			break;
+
+@@ -467,7 +467,7 @@
+
+ 	_build_tunnel_endtile = 0;
+ 	if (transport_type == TRANSPORT_RAIL) {
+-		if (!ValParamRailtype((RailType)p1)) return CMD_ERROR;
++		if (!ValParamRailtype((RailType)GB(p1, 0, 4))) return CMD_ERROR;
+ 	} else {
+ 		const RoadTypes rts = (RoadTypes)GB(p1, 0, 3);
+ 		if (!AreValidRoadTypes(rts) || !HasRoadTypesAvail(_current_player, rts)) return CMD_ERROR;
+Index: src/water_cmd.cpp
+===================================================================
+--- src/water_cmd.cpp	(revision 19678)
++++ src/water_cmd.cpp	(working copy)
+@@ -348,7 +348,7 @@
+ 	int y;
+ 	int sx, sy;
+
+-	if (p1 >= MapSize()) return CMD_ERROR;
++	if (p1 >= MapSize() || p2 > 2) return CMD_ERROR;
+
+ 	/* Outside of the editor you can only build canals, not oceans */
+ 	if (p2 != 0 && _game_mode != GM_EDITOR) return CMD_ERROR;
+Index: src/economy.cpp
+===================================================================
+--- src/economy.cpp	(revision 19678)
++++ src/economy.cpp	(working copy)
+@@ -1503,7 +1503,6 @@
+ 			SetBit(v->vehicle_flags, VF_CARGO_UNLOADING);
+ 			continue;
+ 		}
+-
+ 		GoodsEntry *ge = &st->goods[v->cargo_type];
+ 		const CargoList::List *cargos = v->cargo.Packets();
+
+@@ -1889,6 +1888,7 @@
+ {
+ 	Player *p;
+ 	CommandCost cost(EXPENSES_OTHER);
++	p1 = GB(p1, 0, 8);
+
+ 	/* Check if buying shares is allowed (protection against modified clients) */
+ 	/* Cannot buy own shares */
+@@ -1938,6 +1938,7 @@
+ {
+ 	Player *p;
+ 	Money cost;
++	p1 = GB(p1, 0, 8);
+
+ 	/* Check if selling shares is allowed (protection against modified clients) */
+ 	/* Cannot sell own shares */
+@@ -1975,6 +1976,7 @@
+  */
+ CommandCost CmdBuyCompany(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
++	p1 = GB(p1, 0, 8);
+ 	Player *p;
+ 	PlayerID pid = (PlayerID)p1;
+
+Index: src/rail.cpp
+===================================================================
+--- src/rail.cpp	(revision 19678)
++++ src/rail.cpp	(working copy)
+@@ -186,7 +186,7 @@
+
+ bool ValParamRailtype(const RailType rail)
+ {
+-	return HasRailtypeAvail(_current_player, rail);
++	return rail < RAILTYPE_END && HasRailtypeAvail(_current_player, rail);
+ }
+
+ RailType GetBestRailtype(const PlayerID p)
+Index: src/roadveh_cmd.cpp
+===================================================================
+--- src/roadveh_cmd.cpp	(revision 19678)
++++ src/roadveh_cmd.cpp	(working copy)
+@@ -172,6 +172,7 @@
+ 	UnitID unit_num;
+ 	Engine *e;
+
++	p1 = GB(p1, 0, 16);
+ 	if (!IsEngineBuildable(p1, VEH_ROAD, _current_player)) return_cmd_error(STR_ROAD_VEHICLE_NOT_AVAILABLE);
+
+ 	cost = EstimateRoadVehCost(p1);
+Index: src/vehicle.cpp
+===================================================================
+--- src/vehicle.cpp	(revision 19678)
++++ src/vehicle.cpp	(working copy)
+@@ -1763,6 +1763,7 @@
+ 	CommandCost cost;
+ 	VehicleType vehicle_type = (VehicleType)GB(p1, 0, 8);
+
++	if (!IsPlayerBuildableVehicleType(vehicle_type)) return CMD_ERROR;
+ 	if (!IsDepotTile(tile) || !IsTileOwner(tile, _current_player)) return CMD_ERROR;
+
+ 	/* Get the list of vehicles in the depot */
+@@ -1826,8 +1827,10 @@
+ 	CommandCost cost, total_cost(EXPENSES_NEW_VEHICLES);
+ 	uint32 build_argument = 2;
+
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidVehicleID(p1)) return CMD_ERROR;
+ 	v = GetVehicle(p1);
++	if (!v->IsPrimaryVehicle()) return CMD_ERROR;
+ 	v_front = v;
+ 	w = NULL;
+ 	w_front = NULL;
+@@ -2162,7 +2165,7 @@
+ 			}
+ 			break;
+
+-		default: NOT_REACHED(); break;
++		default: return 0;
+ 	}
+
+ 	if ((n + 100) < *length_of_array) {
+@@ -2395,11 +2398,12 @@
+ {
+ 	Vehicle *v;
+
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidVehicleID(p1) || StrEmpty(_cmd_text)) return CMD_ERROR;
+
+ 	v = GetVehicle(p1);
+
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	if (!IsUniqueVehicleName(_cmd_text)) return_cmd_error(STR_NAME_MUST_BE_UNIQUE);
+
+@@ -2425,11 +2429,12 @@
+ 	Vehicle* v;
+ 	uint16 serv_int = GetServiceIntervalClamped(p2); /* Double check the service interval from the user-input */
+
++	p1 = GB(p1, 0, 16);
+ 	if (serv_int != p2 || !IsValidVehicleID(p1)) return CMD_ERROR;
+
+ 	v = GetVehicle(p1);
+
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+ 		v->service_interval = serv_int;
+Index: src/industry_cmd.cpp
+===================================================================
+--- src/industry_cmd.cpp	(revision 19678)
++++ src/industry_cmd.cpp	(working copy)
+@@ -1624,8 +1624,11 @@
+  */
+ CommandCost CmdBuildIndustry(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
+-	const IndustrySpec *indspec = GetIndustrySpec(GB(p1, 0, 16));
++	IndustryType it = GB(p1, 0, 16);
++	if (it >= NUM_INDUSTRYTYPES) return CMD_ERROR;
+
++	const IndustrySpec *indspec = GetIndustrySpec(it);
++
+ 	/* Check if the to-be built/founded industry is available for this climate. */
+ 	if (!indspec->enabled) {
+ 		return CMD_ERROR;
+@@ -1648,7 +1651,7 @@
+ 					 * because parameter evaluation order is not guaranteed in the c++ standard
+ 					 */
+ 					tile = RandomTile();
+-					const Industry *ind = CreateNewIndustryHelper(tile, p1, flags, indspec, RandomRange(indspec->num_table), p2);
++					const Industry *ind = CreateNewIndustryHelper(tile, it, flags, indspec, RandomRange(indspec->num_table), p2);
+ 					if (ind != NULL) {
+ 						SetDParam(0, indspec->name);
+ 						if (indspec->new_industry_text > STR_LAST_STRINGID) {
+@@ -1675,7 +1678,7 @@
+ 			if (--num < 0) num = indspec->num_table - 1;
+ 		} while (!CheckIfIndustryTilesAreFree(tile, itt[num], num, p1));
+
+-		if (CreateNewIndustryHelper(tile, p1, flags, indspec, num, p2) == NULL) return CMD_ERROR;
++		if (CreateNewIndustryHelper(tile, it, flags, indspec, num, p2) == NULL) return CMD_ERROR;
+ 	}
+
+ 	return CommandCost(EXPENSES_OTHER, indspec->GetConstructionCost());
+Index: src/aircraft_cmd.cpp
+===================================================================
+--- src/aircraft_cmd.cpp	(revision 19678)
++++ src/aircraft_cmd.cpp	(working copy)
+@@ -276,6 +276,7 @@
+  */
+ CommandCost CmdBuildAircraft(TileIndex tile, uint32 flags, uint32 p1, uint32 p2)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsEngineBuildable(p1, VEH_AIRCRAFT, _current_player)) return_cmd_error(STR_AIRCRAFT_NOT_AVAILABLE);
+
+ 	const AircraftVehicleInfo *avi = AircraftVehInfo(p1);

--- a/_security/CVE-2010-0402/0.7.0 - 0.7.5.patch
+++ b/_security/CVE-2010-0402/0.7.0 - 0.7.5.patch
@@ -1,0 +1,628 @@
+---
+layout: security_patch
+cve: CVE-2010-0402
+first_version: 0.7.0
+last_version: 0.7.5
+---
+
+Index: src/terraform_cmd.cpp
+===================================================================
+--- src/terraform_cmd.cpp	(revision 19678)
++++ src/terraform_cmd.cpp	(working copy)
+@@ -364,7 +364,7 @@
+ 	uint oldh = TileHeight(p1);
+
+ 	/* compute new height */
+-	uint h = oldh + p2;
++	uint h = oldh + (int8)p2;
+
+ 	/* Check range of destination height */
+ 	if (h > MAX_TILE_HEIGHT) return_cmd_error((oldh == 0) ? STR_1003_ALREADY_AT_SEA_LEVEL : STR_1004_TOO_HIGH);
+Index: src/rail_cmd.cpp
+===================================================================
+--- src/rail_cmd.cpp	(revision 19678)
++++ src/rail_cmd.cpp	(working copy)
+@@ -306,8 +306,8 @@
+ CommandCost CmdBuildSingleRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+ 	Slope tileh;
+-	RailType railtype = (RailType)p1;
+-	Track track = (Track)p2;
++	RailType railtype = (RailType)GB(p1, 0, 4);
++	Track track = (Track)GB(p2, 0, 3);
+ 	TrackBits trackbit;
+ 	CommandCost cost(EXPENSES_CONSTRUCTION);
+ 	CommandCost ret;
+@@ -442,12 +442,12 @@
+  */
+ CommandCost CmdRemoveSingleRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+-	Track track = (Track)p2;
++	Track track = (Track)GB(p2, 0, 3);
+ 	TrackBits trackbit;
+ 	CommandCost cost(EXPENSES_CONSTRUCTION, _price.remove_rail );
+ 	bool crossing = false;
+
+-	if (!ValParamTrackOrientation((Track)p2)) return CMD_ERROR;
++	if (!ValParamTrackOrientation(track)) return CMD_ERROR;
+ 	trackbit = TrackToTrackBits(track);
+
+ 	/* Need to read tile owner now because it may change when the rail is removed
+@@ -751,6 +751,7 @@
+ 	Slope tileh;
+
+ 	/* check railtype and valid direction for depot (0 through 3), 4 in total */
++	p1 = GB(p1, 0, 4);
+ 	if (!ValParamRailtype((RailType)p1)) return CMD_ERROR;
+
+ 	tileh = GetTileSlope(tile, NULL);
+@@ -824,6 +825,7 @@
+ 	uint num_dir_cycle = GB(p1, 15, 2);
+
+ 	if (sigtype > SIGTYPE_LAST) return CMD_ERROR;
++	if (cycle_start > cycle_stop || cycle_stop > SIGTYPE_LAST) return CMD_ERROR;
+
+ 	/* You can only build signals on plain rail tiles, and the selected track must exist */
+ 	if (!ValParamTrackOrientation(track) || !IsPlainRailTile(tile) ||
+@@ -1040,10 +1042,9 @@
+ 	bool semaphores = HasBit(p2, 4);
+ 	bool remove = HasBit(p2, 5);
+ 	bool autofill = HasBit(p2, 6);
+-	Trackdir trackdir = TrackToTrackdir(track);
+ 	byte signal_density = GB(p2, 24, 8);
+
+-	if (p1 >= MapSize()) return CMD_ERROR;
++	if (p1 >= MapSize() || !ValParamTrackOrientation(track)) return CMD_ERROR;
+ 	end_tile = p1;
+ 	if (signal_density == 0 || signal_density > 20) return CMD_ERROR;
+
+@@ -1053,6 +1054,7 @@
+ 	 * since the original amount will be too dense (shorter tracks) */
+ 	signal_density *= 2;
+
++	Trackdir trackdir = TrackToTrackdir(track);
+ 	if (CmdFailed(ValidateAutoDrag(&trackdir, tile, end_tile))) return CMD_ERROR;
+
+ 	track = TrackdirToTrack(trackdir); // trackdir might have changed, keep track in sync
+@@ -1250,7 +1252,7 @@
+ CommandCost CmdConvertRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+ 	CommandCost cost(EXPENSES_CONSTRUCTION);
+-	RailType totype = (RailType)p2;
++	RailType totype = (RailType)GB(p2, 0, 4);
+
+ 	if (!ValParamRailtype(totype)) return CMD_ERROR;
+ 	if (p1 >= MapSize()) return CMD_ERROR;
+Index: src/group_cmd.cpp
+===================================================================
+--- src/group_cmd.cpp	(revision 19678)
++++ src/group_cmd.cpp	(working copy)
+@@ -77,7 +77,7 @@
+  */
+ CommandCost CmdCreateGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+-	VehicleType vt = (VehicleType)p1;
++	VehicleType vt = (VehicleType)GB(p1, 0, 3);
+ 	if (!IsCompanyBuildableVehicleType(vt)) return CMD_ERROR;
+
+ 	if (!Group::CanAllocateItem()) return CMD_ERROR;
+@@ -105,6 +105,7 @@
+  */
+ CommandCost CmdDeleteGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidGroupID(p1)) return CMD_ERROR;
+
+ 	Group *g = GetGroup(p1);
+@@ -164,6 +165,7 @@
+  */
+ CommandCost CmdRenameGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidGroupID(p1)) return CMD_ERROR;
+
+ 	Group *g = GetGroup(p1);
+@@ -199,6 +201,8 @@
+  */
+ CommandCost CmdAddVehicleGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
++	p2 = GB(p2, 0, 16);
+ 	GroupID new_g = p1;
+
+ 	if (!IsValidVehicleID(p2) || (!IsValidGroupID(new_g) && !IsDefaultGroupID(new_g))) return CMD_ERROR;
+@@ -246,12 +250,12 @@
+  */
+ CommandCost CmdAddSharedVehicleGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+-	VehicleType type = (VehicleType)p2;
++	p1 = GB(p1, 0, 16);
++	VehicleType type = (VehicleType)GB(p2, 0, 3);
+ 	if (!IsValidGroupID(p1) || !IsCompanyBuildableVehicleType(type)) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+ 		Vehicle *v;
+-		VehicleType type = (VehicleType)p2;
+ 		GroupID id_g = p1;
+
+ 		/* Find the first front engine which belong to the group id_g
+@@ -283,7 +287,8 @@
+  */
+ CommandCost CmdRemoveAllVehiclesGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+-	VehicleType type = (VehicleType)p2;
++	p1 = GB(p1, 0, 16);
++	VehicleType type = (VehicleType)GB(p2, 0, 3);
+ 	if (!IsValidGroupID(p1) || !IsCompanyBuildableVehicleType(type)) return CMD_ERROR;
+
+ 	Group *g = GetGroup(p1);
+@@ -320,6 +325,7 @@
+  */
+ CommandCost CmdSetGroupReplaceProtection(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidGroupID(p1)) return CMD_ERROR;
+
+ 	Group *g = GetGroup(p1);
+Index: src/vehiclelist.h
+===================================================================
+--- src/vehiclelist.h	(revision 19678)
++++ src/vehiclelist.h	(working copy)
+@@ -9,7 +9,7 @@
+
+ typedef SmallVector<const Vehicle *, 32> VehicleList;
+
+-void GenerateVehicleSortList(VehicleList *list, VehicleType type, Owner owner, uint32 index, uint16 window_type);
++bool GenerateVehicleSortList(VehicleList *list, VehicleType type, Owner owner, uint32 index, uint16 window_type);
+ void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine_list, VehicleList *wagon_list, bool individual_wagons = false);
+
+ #endif /* VEHICLELIST_H */
+Index: src/station_cmd.cpp
+===================================================================
+--- src/station_cmd.cpp	(revision 19678)
++++ src/station_cmd.cpp	(working copy)
+@@ -1356,6 +1356,7 @@
+  */
+ CommandCost CmdBuildRoadStop(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 2);
+ 	bool type = HasBit(p2, 0);
+ 	bool is_drive_through = HasBit(p2, 1);
+ 	bool build_over_road  = is_drive_through && IsNormalRoadTile(tile);
+@@ -2911,6 +2912,7 @@
+  */
+ CommandCost CmdRenameStation(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidStationID(p1)) return CMD_ERROR;
+
+ 	Station *st = GetStation(p1);
+Index: src/vehiclelist.cpp
+===================================================================
+--- src/vehiclelist.cpp	(revision 19678)
++++ src/vehiclelist.cpp	(working copy)
+@@ -67,8 +67,9 @@
+  *      <li>VLW_WAYPOINT_LIST: index of waypoint to generate a list for</li>
+  *    </ul>
+  * @param window_type The type of window the list is for, using the VLW_ flags in vehicle_gui.h
++ * @return false if invalid list is requested
+  */
+-void GenerateVehicleSortList(VehicleList *list, VehicleType type, Owner owner, uint32 index, uint16 window_type)
++bool GenerateVehicleSortList(VehicleList *list, VehicleType type, Owner owner, uint32 index, uint16 window_type)
+ {
+ 	list->Clear();
+
+@@ -92,7 +93,10 @@
+
+ 		case VLW_SHARED_ORDERS:
+ 			/* Add all vehicles from this vehicle's shared order list */
+-			for (v = GetVehicle(index); v != NULL; v = v->NextShared()) {
++			v = IsValidVehicleID(index) ? GetVehicle(index) : NULL;
++			if (v == NULL || v->type != type || !v->IsPrimaryVehicle()) return false;
++
++			for (; v != NULL; v = v->NextShared()) {
+ 				*list->Append() = v;
+ 			}
+ 			break;
+@@ -144,8 +148,9 @@
+ 			}
+ 			break;
+
+-		default: NOT_REACHED(); break;
++		default: return false;
+ 	}
+
+ 	list->Compact();
++	return true;
+ }
+Index: src/ship_cmd.cpp
+===================================================================
+--- src/ship_cmd.cpp	(revision 19678)
++++ src/ship_cmd.cpp	(working copy)
+@@ -723,6 +723,7 @@
+  */
+ CommandCost CmdBuildShip(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	UnitID unit_num;
+
+ 	if (!IsEngineBuildable(p1, VEH_SHIP, _current_company)) return_cmd_error(STR_SHIP_NOT_AVAILABLE);
+Index: src/order_cmd.cpp
+===================================================================
+--- src/order_cmd.cpp	(revision 19678)
++++ src/order_cmd.cpp	(working copy)
+@@ -442,7 +442,7 @@
+
+ 	v = GetVehicle(veh);
+
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* Check if the inserted order is to the correct destination (owner, type),
+ 	 * and has the correct flags if any */
+@@ -512,8 +512,6 @@
+ 						default: return CMD_ERROR;
+ 					}
+ 				}
+-			} else {
+-				if (!IsCompanyBuildableVehicleType(v)) return CMD_ERROR;
+ 			}
+
+ 			if (new_order.GetNonStopType() != ONSF_STOP_EVERYWHERE && v->type != VEH_TRAIN && v->type != VEH_ROAD) return CMD_ERROR;
+@@ -669,15 +667,15 @@
+ CommandCost CmdDeleteOrder(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+ 	Vehicle *v;
+-	VehicleID veh_id = p1;
+-	VehicleOrderID sel_ord = p2;
++	VehicleID veh_id = GB(p1, 0, 16);
++	VehicleOrderID sel_ord = GB(p2, 0, 8);
+ 	Order *order;
+
+ 	if (!IsValidVehicleID(veh_id)) return CMD_ERROR;
+
+ 	v = GetVehicle(veh_id);
+
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* If we did not select an order, we maybe want to de-clone the orders */
+ 	if (sel_ord >= v->GetNumOrders())
+@@ -737,14 +735,14 @@
+ CommandCost CmdSkipToOrder(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+ 	Vehicle *v;
+-	VehicleID veh_id = p1;
+-	VehicleOrderID sel_ord = p2;
++	VehicleID veh_id = GB(p1, 0, 16);
++	VehicleOrderID sel_ord = GB(p2, 0, 8);
+
+ 	if (!IsValidVehicleID(veh_id)) return CMD_ERROR;
+
+ 	v = GetVehicle(veh_id);
+
+-	if (!CheckOwnership(v->owner) || sel_ord == v->cur_order_index ||
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner) || sel_ord == v->cur_order_index ||
+ 			sel_ord >= v->GetNumOrders() || v->GetNumOrders() < 2) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+@@ -776,14 +774,14 @@
+  */
+ CommandCost CmdMoveOrder(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+-	VehicleID veh = p1;
++	VehicleID veh = GB(p1, 0, 16);
+ 	VehicleOrderID moving_order = GB(p2,  0, 16);
+ 	VehicleOrderID target_order = GB(p2, 16, 16);
+
+ 	if (!IsValidVehicleID(veh)) return CMD_ERROR;
+
+ 	Vehicle *v = GetVehicle(veh);
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* Don't make senseless movements */
+ 	if (moving_order >= v->GetNumOrders() || target_order >= v->GetNumOrders() ||
+@@ -863,7 +861,7 @@
+ 	if (!IsValidVehicleID(veh)) return CMD_ERROR;
+
+ 	Vehicle *v = GetVehicle(veh);
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* Is it a valid order? */
+ 	if (sel_ord >= v->GetNumOrders()) return CMD_ERROR;
+@@ -1079,7 +1077,7 @@
+
+ 	dst = GetVehicle(veh_dst);
+
+-	if (!CheckOwnership(dst->owner)) return CMD_ERROR;
++	if (!dst->IsPrimaryVehicle() || !CheckOwnership(dst->owner)) return CMD_ERROR;
+
+ 	switch (p2) {
+ 		case CO_SHARE: {
+@@ -1090,7 +1088,7 @@
+ 			src = GetVehicle(veh_src);
+
+ 			/* Sanity checks */
+-			if (!CheckOwnership(src->owner) || dst->type != src->type || dst == src)
++			if (!src->IsPrimaryVehicle() || !CheckOwnership(src->owner) || dst->type != src->type || dst == src)
+ 				return CMD_ERROR;
+
+ 			/* Trucks can't share orders with busses (and visa versa) */
+@@ -1135,7 +1133,7 @@
+ 			src = GetVehicle(veh_src);
+
+ 			/* Sanity checks */
+-			if (!CheckOwnership(src->owner) || dst->type != src->type || dst == src)
++			if (!src->IsPrimaryVehicle() || !CheckOwnership(src->owner) || dst->type != src->type || dst == src)
+ 				return CMD_ERROR;
+
+ 			/* Trucks can't copy all the orders from busses (and visa versa),
+@@ -1206,11 +1204,12 @@
+ 	CargoID cargo = GB(p2, 0, 8);
+ 	byte subtype  = GB(p2, 8, 8);
+
++	if (cargo >= NUM_CARGO) return CMD_ERROR;
+ 	if (!IsValidVehicleID(veh)) return CMD_ERROR;
+
+ 	v = GetVehicle(veh);
+
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	order = GetVehicleOrder(v, order_number);
+ 	if (order == NULL) return CMD_ERROR;
+@@ -1359,12 +1358,13 @@
+ 	VehicleOrderID cur_ord = GB(p2,  0, 16);
+ 	uint16 serv_int = GB(p2, 16, 16);
+
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidVehicleID(p1)) return CMD_ERROR;
+
+ 	v = GetVehicle(p1);
+
+ 	/* Check the vehicle type and ownership, and if the service interval and order are in range */
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+ 	if (serv_int != GetServiceIntervalClamped(serv_int) || cur_ord >= v->GetNumOrders()) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+Index: src/vehicle_cmd.cpp
+===================================================================
+--- src/vehicle_cmd.cpp	(revision 19678)
++++ src/vehicle_cmd.cpp	(working copy)
+@@ -13,6 +13,7 @@
+ #include "newgrf_engine.h"
+ #include "newgrf_text.h"
+ #include "functions.h"
++#include "cmd_helper.h"
+ #include "window_func.h"
+ #include "vehicle_func.h"
+ #include "string_func.h"
+@@ -134,15 +135,17 @@
+ {
+ 	VehicleList list;
+ 	CommandCost return_value = CMD_ERROR;
+-	VehicleType vehicle_type = (VehicleType)GB(p2, 0, 5);
++	VehicleType vehicle_type = (VehicleType)GB(p2, 0, 3);
+ 	bool start_stop = HasBit(p2, 5);
+ 	bool vehicle_list_window = HasBit(p2, 6);
+
++	if (!IsCompanyBuildableVehicleType(vehicle_type)) return CMD_ERROR;
++
+ 	if (vehicle_list_window) {
+ 		uint32 id = p1;
+ 		uint16 window_type = p2 & VLW_MASK;
+
+-		GenerateVehicleSortList(&list, vehicle_type, _current_company, id, window_type);
++		if (!GenerateVehicleSortList(&list, vehicle_type, _current_company, id, window_type)) return CMD_ERROR;
+ 	} else {
+ 		/* Get the list of vehicles in the depot */
+ 		BuildDepotVehicleList(vehicle_type, tile, &list, NULL);
+@@ -186,8 +189,10 @@
+
+ 	CommandCost cost(EXPENSES_NEW_VEHICLES);
+ 	uint sell_command;
+-	VehicleType vehicle_type = (VehicleType)GB(p1, 0, 8);
++	VehicleType vehicle_type = (VehicleType)GB(p1, 0, 3);
+
++	if (!IsCompanyBuildableVehicleType(vehicle_type)) return CMD_ERROR;
++
+ 	switch (vehicle_type) {
+ 		case VEH_TRAIN:    sell_command = CMD_SELL_RAIL_WAGON; break;
+ 		case VEH_ROAD:     sell_command = CMD_SELL_ROAD_VEH;   break;
+@@ -221,9 +226,10 @@
+ {
+ 	VehicleList list;
+ 	CommandCost cost = CommandCost(EXPENSES_NEW_VEHICLES);
+-	VehicleType vehicle_type = (VehicleType)GB(p1, 0, 8);
++	VehicleType vehicle_type = (VehicleType)GB(p1, 0, 3);
+ 	bool all_or_nothing = HasBit(p2, 0);
+
++	if (!IsCompanyBuildableVehicleType(vehicle_type)) return CMD_ERROR;
+ 	if (!IsDepotTile(tile) || !IsTileOwner(tile, _current_company)) return CMD_ERROR;
+
+ 	/* Get the list of vehicles in the depot */
+@@ -335,9 +341,11 @@
+ 	CommandCost total_cost(EXPENSES_NEW_VEHICLES);
+ 	uint32 build_argument = 2;
+
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidVehicleID(p1)) return CMD_ERROR;
+
+ 	Vehicle *v = GetVehicle(p1);
++	if (!v->IsPrimaryVehicle()) return CMD_ERROR;
+ 	Vehicle *v_front = v;
+ 	Vehicle *w = NULL;
+ 	Vehicle *w_front = NULL;
+@@ -519,7 +527,7 @@
+ {
+ 	VehicleList list;
+
+-	GenerateVehicleSortList(&list, type, owner, id, vlw_flag);
++	if (!GenerateVehicleSortList(&list, type, owner, id, vlw_flag)) return CMD_ERROR;
+
+ 	/* Send all the vehicles to a depot */
+ 	for (uint i = 0; i < list.Length(); i++) {
+@@ -546,10 +554,11 @@
+  */
+ CommandCost CmdRenameVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidVehicleID(p1)) return CMD_ERROR;
+
+ 	Vehicle *v = GetVehicle(p1);
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	bool reset = StrEmpty(text);
+
+@@ -577,13 +586,14 @@
+  */
+ CommandCost CmdChangeServiceInt(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	uint16 serv_int = GetServiceIntervalClamped(p2); // Double check the service interval from the user-input
+
+ 	if (serv_int != p2 || !IsValidVehicleID(p1)) return CMD_ERROR;
+
+ 	Vehicle *v = GetVehicle(p1);
+
+-	if (!CheckOwnership(v->owner)) return CMD_ERROR;
++	if (!v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+ 		v->service_interval = serv_int;
+Index: src/train_cmd.cpp
+===================================================================
+--- src/train_cmd.cpp	(revision 19678)
++++ src/train_cmd.cpp	(working copy)
+@@ -724,6 +724,7 @@
+  */
+ CommandCost CmdBuildRailVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	/* Check if the engine-type is valid (for the company) */
+ 	if (!IsEngineBuildable(p1, VEH_TRAIN, _current_company)) return_cmd_error(STR_RAIL_VEHICLE_NOT_AVAILABLE);
+
+Index: src/tunnelbridge_cmd.cpp
+===================================================================
+--- src/tunnelbridge_cmd.cpp	(revision 19678)
++++ src/tunnelbridge_cmd.cpp	(working copy)
+@@ -215,7 +215,7 @@
+ 			break;
+
+ 		case TRANSPORT_RAIL:
+-			railtype = (RailType)GB(p2, 8, 7);
++			railtype = (RailType)GB(p2, 8, 4);
+ 			if (!ValParamRailtype(railtype)) return CMD_ERROR;
+ 			break;
+
+@@ -479,7 +479,7 @@
+
+ 	_build_tunnel_endtile = 0;
+ 	if (transport_type == TRANSPORT_RAIL) {
+-		if (!ValParamRailtype((RailType)p1)) return CMD_ERROR;
++		if (!ValParamRailtype((RailType)GB(p1, 0, 4))) return CMD_ERROR;
+ 	} else {
+ 		const RoadTypes rts = (RoadTypes)GB(p1, 0, 2);
+ 		if (!AreValidRoadTypes(rts) || !HasRoadTypesAvail(_current_company, rts)) return CMD_ERROR;
+Index: src/waypoint_cmd.cpp
+===================================================================
+--- src/waypoint_cmd.cpp	(revision 19678)
++++ src/waypoint_cmd.cpp	(working copy)
+@@ -314,6 +314,7 @@
+  */
+ CommandCost CmdRenameWaypoint(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsValidWaypointID(p1)) return CMD_ERROR;
+
+ 	Waypoint *wp = GetWaypoint(p1);
+Index: src/water_cmd.cpp
+===================================================================
+--- src/water_cmd.cpp	(revision 19678)
++++ src/water_cmd.cpp	(working copy)
+@@ -288,7 +288,7 @@
+ 	int y;
+ 	int sx, sy;
+
+-	if (p1 >= MapSize()) return CMD_ERROR;
++	if (p1 >= MapSize() || p2 > 2) return CMD_ERROR;
+
+ 	/* Outside of the editor you can only build canals, not oceans */
+ 	if (p2 != 0 && _game_mode != GM_EDITOR) return CMD_ERROR;
+Index: src/economy.cpp
+===================================================================
+--- src/economy.cpp	(revision 19678)
++++ src/economy.cpp	(working copy)
+@@ -1504,7 +1504,6 @@
+ 	/* Handle end of route payment */
+ 	Money profit = DeliverGoods(count, this->ct, cp->source, this->current_station, cp->source_xy, cp->days_in_transit, this->owner);
+ 	this->route_profit += profit;
+-
+ 	/* The vehicle's profit is whatever route profit there is minus feeder shares. */
+ 	this->visual_profit += profit - cp->feeder_share;
+ }
+@@ -1929,6 +1928,7 @@
+  */
+ CommandCost CmdBuyShareInCompany(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 8);
+ 	CommandCost cost(EXPENSES_OTHER);
+
+ 	/* Check if buying shares is allowed (protection against modified clients)
+@@ -1974,6 +1974,7 @@
+  */
+ CommandCost CmdSellShareInCompany(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 8);
+ 	/* Check if selling shares is allowed (protection against modified clients)
+ 	 * Cannot sell own shares */
+ 	if (!IsValidCompanyID((CompanyID)p1) || !_settings_game.economy.allow_shares || _current_company == (CompanyID)p1) return CMD_ERROR;
+@@ -2007,6 +2008,7 @@
+  */
+ CommandCost CmdBuyCompany(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 8);
+ 	CompanyID cid = (CompanyID)p1;
+
+ 	/* Disable takeovers in multiplayer games */
+Index: src/rail.cpp
+===================================================================
+--- src/rail.cpp	(revision 19678)
++++ src/rail.cpp	(working copy)
+@@ -175,7 +175,7 @@
+
+ bool ValParamRailtype(const RailType rail)
+ {
+-	return HasRailtypeAvail(_current_company, rail);
++	return rail < RAILTYPE_END && HasRailtypeAvail(_current_company, rail);
+ }
+
+ RailType GetBestRailtype(const CompanyID company)
+Index: src/roadveh_cmd.cpp
+===================================================================
+--- src/roadveh_cmd.cpp	(revision 19678)
++++ src/roadveh_cmd.cpp	(working copy)
+@@ -165,6 +165,7 @@
+ 	Vehicle *v;
+ 	UnitID unit_num;
+
++	p1 = GB(p1, 0, 16);
+ 	if (!IsEngineBuildable(p1, VEH_ROAD, _current_company)) return_cmd_error(STR_ROAD_VEHICLE_NOT_AVAILABLE);
+
+ 	const Engine *e = GetEngine(p1);
+Index: src/aircraft_cmd.cpp
+===================================================================
+--- src/aircraft_cmd.cpp	(revision 19678)
++++ src/aircraft_cmd.cpp	(working copy)
+@@ -248,6 +248,7 @@
+  */
+ CommandCost CmdBuildAircraft(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsEngineBuildable(p1, VEH_AIRCRAFT, _current_company)) return_cmd_error(STR_AIRCRAFT_NOT_AVAILABLE);
+
+ 	const AircraftVehicleInfo *avi = AircraftVehInfo(p1);

--- a/_security/CVE-2010-0402/1.0.0 - 1.0.0.patch
+++ b/_security/CVE-2010-0402/1.0.0 - 1.0.0.patch
@@ -1,0 +1,535 @@
+---
+layout: security_patch
+cve: CVE-2010-0402
+first_version: 1.0.0
+last_version: 1.0.0
+---
+
+Index: src/terraform_cmd.cpp
+===================================================================
+--- src/terraform_cmd.cpp	(revision 19678)
++++ src/terraform_cmd.cpp	(working copy)
+@@ -372,7 +372,7 @@
+ 	uint oldh = TileHeight(p1);
+
+ 	/* compute new height */
+-	uint h = oldh + p2;
++	uint h = oldh + (int8)p2;
+
+ 	/* Check range of destination height */
+ 	if (h > MAX_TILE_HEIGHT) return_cmd_error((oldh == 0) ? STR_ERROR_ALREADY_AT_SEA_LEVEL : STR_ERROR_TOO_HIGH);
+Index: src/rail_cmd.cpp
+===================================================================
+--- src/rail_cmd.cpp	(revision 19678)
++++ src/rail_cmd.cpp	(working copy)
+@@ -369,8 +369,8 @@
+  */
+ CommandCost CmdBuildSingleRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+-	RailType railtype = (RailType)p1;
+-	Track track = (Track)p2;
++	RailType railtype = (RailType)GB(p1, 0, 4);
++	Track track = (Track)GB(p2, 0, 3);
+ 	CommandCost cost(EXPENSES_CONSTRUCTION);
+
+ 	if (!ValParamRailtype(railtype) || !ValParamTrackOrientation(track)) return CMD_ERROR;
+@@ -509,11 +509,11 @@
+  */
+ CommandCost CmdRemoveSingleRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+-	Track track = (Track)p2;
++	Track track = (Track)GB(p2, 0, 3);
+ 	CommandCost cost(EXPENSES_CONSTRUCTION);
+ 	bool crossing = false;
+
+-	if (!ValParamTrackOrientation((Track)p2)) return CMD_ERROR;
++	if (!ValParamTrackOrientation(track)) return CMD_ERROR;
+ 	TrackBits trackbit = TrackToTrackBits(track);
+
+ 	/* Need to read tile owner now because it may change when the rail is removed
+@@ -830,6 +830,7 @@
+ CommandCost CmdBuildTrainDepot(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+ 	/* check railtype and valid direction for depot (0 through 3), 4 in total */
++	p1 = GB(p1, 0, 4);
+ 	if (!ValParamRailtype((RailType)p1)) return CMD_ERROR;
+
+ 	Slope tileh = GetTileSlope(tile, NULL);
+@@ -905,6 +906,7 @@
+ 	uint num_dir_cycle = GB(p1, 15, 2);
+
+ 	if (sigtype > SIGTYPE_LAST) return CMD_ERROR;
++	if (cycle_start > cycle_stop || cycle_stop > SIGTYPE_LAST) return CMD_ERROR;
+
+ 	/* You can only build signals on plain rail tiles, and the selected track must exist */
+ 	if (!ValParamTrackOrientation(track) || !IsPlainRailTile(tile) ||
+@@ -1127,10 +1129,9 @@
+ 	bool semaphores = HasBit(p2, 4);
+ 	bool remove = HasBit(p2, 5);
+ 	bool autofill = HasBit(p2, 6);
+-	Trackdir trackdir = TrackToTrackdir(track);
+ 	byte signal_density = GB(p2, 24, 8);
+
+-	if (p1 >= MapSize()) return CMD_ERROR;
++	if (p1 >= MapSize() || !ValParamTrackOrientation(track)) return CMD_ERROR;
+ 	TileIndex end_tile = p1;
+ 	if (signal_density == 0 || signal_density > 20) return CMD_ERROR;
+
+@@ -1140,6 +1141,7 @@
+ 	 * since the original amount will be too dense (shorter tracks) */
+ 	signal_density *= 2;
+
++	Trackdir trackdir = TrackToTrackdir(track);
+ 	if (ValidateAutoDrag(&trackdir, tile, end_tile).Failed()) return CMD_ERROR;
+
+ 	track = TrackdirToTrack(trackdir); // trackdir might have changed, keep track in sync
+@@ -1361,7 +1363,7 @@
+ CommandCost CmdConvertRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+ 	CommandCost cost(EXPENSES_CONSTRUCTION);
+-	RailType totype = (RailType)p2;
++	RailType totype = (RailType)GB(p2, 0, 4);
+
+ 	if (!ValParamRailtype(totype)) return CMD_ERROR;
+ 	if (p1 >= MapSize()) return CMD_ERROR;
+Index: src/group_cmd.cpp
+===================================================================
+--- src/group_cmd.cpp	(revision 19678)
++++ src/group_cmd.cpp	(working copy)
+@@ -82,7 +82,7 @@
+  */
+ CommandCost CmdCreateGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+-	VehicleType vt = (VehicleType)p1;
++	VehicleType vt = (VehicleType)GB(p1, 0, 3);
+ 	if (!IsCompanyBuildableVehicleType(vt)) return CMD_ERROR;
+
+ 	if (!Group::CanAllocateItem()) return CMD_ERROR;
+@@ -258,13 +258,12 @@
+  */
+ CommandCost CmdAddSharedVehicleGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+-	VehicleType type = (VehicleType)p2;
+-	if (!Group::IsValidID(p1) || !IsCompanyBuildableVehicleType(type)) return CMD_ERROR;
++	VehicleType type = (VehicleType)GB(p2, 0, 3);
++	GroupID id_g = p1;
++	if (!Group::IsValidID(id_g) || !IsCompanyBuildableVehicleType(type)) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+ 		Vehicle *v;
+-		VehicleType type = (VehicleType)p2;
+-		GroupID id_g = p1;
+
+ 		/* Find the first front engine which belong to the group id_g
+ 		 * then add all shared vehicles of this front engine to the group id_g */
+@@ -298,13 +297,13 @@
+  */
+ CommandCost CmdRemoveAllVehiclesGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+-	Group *g = Group::GetIfValid(p1);
+-	VehicleType type = (VehicleType)p2;
++	GroupID old_g = p1;
++	Group *g = Group::GetIfValid(old_g);
++	VehicleType type = (VehicleType)GB(p2, 0, 3);
+
+ 	if (g == NULL || g->owner != _current_company || !IsCompanyBuildableVehicleType(type)) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+-		GroupID old_g = p1;
+ 		Vehicle *v;
+
+ 		/* Find each Vehicle that belongs to the group old_g and add it to the default group */
+Index: src/vehiclelist.h
+===================================================================
+--- src/vehiclelist.h	(revision 19678)
++++ src/vehiclelist.h	(working copy)
+@@ -19,7 +19,7 @@
+
+ typedef SmallVector<const Vehicle *, 32> VehicleList;
+
+-void GenerateVehicleSortList(VehicleList *list, VehicleType type, Owner owner, uint32 index, uint16 window_type);
++bool GenerateVehicleSortList(VehicleList *list, VehicleType type, Owner owner, uint32 index, uint16 window_type);
+ void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine_list, VehicleList *wagon_list, bool individual_wagons = false);
+
+ #endif /* VEHICLELIST_H */
+Index: src/station_cmd.cpp
+===================================================================
+--- src/station_cmd.cpp	(revision 19678)
++++ src/station_cmd.cpp	(working copy)
+@@ -1521,6 +1521,7 @@
+  */
+ CommandCost CmdBuildRoadStop(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 2);
+ 	bool type = HasBit(p2, 0);
+ 	bool is_drive_through = HasBit(p2, 1);
+ 	bool build_over_road  = is_drive_through && IsNormalRoadTile(tile);
+Index: src/vehiclelist.cpp
+===================================================================
+--- src/vehiclelist.cpp	(revision 19678)
++++ src/vehiclelist.cpp	(working copy)
+@@ -76,8 +76,9 @@
+  *      <li>VLW_WAYPOINT_LIST: index of waypoint to generate a list for</li>
+  *    </ul>
+  * @param window_type The type of window the list is for, using the VLW_ flags in vehicle_gui.h
++ * @return false if invalid list is requested
+  */
+-void GenerateVehicleSortList(VehicleList *list, VehicleType type, Owner owner, uint32 index, uint16 window_type)
++bool GenerateVehicleSortList(VehicleList *list, VehicleType type, Owner owner, uint32 index, uint16 window_type)
+ {
+ 	list->Clear();
+
+@@ -101,7 +102,10 @@
+
+ 		case VLW_SHARED_ORDERS:
+ 			/* Add all vehicles from this vehicle's shared order list */
+-			for (v = Vehicle::Get(index); v != NULL; v = v->NextShared()) {
++			v = Vehicle::GetIfValid(index);
++			if (v == NULL || v->type != type || !v->IsPrimaryVehicle()) return false;
++
++			for (; v != NULL; v = v->NextShared()) {
+ 				*list->Append() = v;
+ 			}
+ 			break;
+@@ -153,8 +157,9 @@
+ 			}
+ 			break;
+
+-		default: NOT_REACHED();
++		default: return false;
+ 	}
+
+ 	list->Compact();
++	return true;
+ }
+Index: src/ship_cmd.cpp
+===================================================================
+--- src/ship_cmd.cpp	(revision 19678)
++++ src/ship_cmd.cpp	(working copy)
+@@ -611,6 +611,7 @@
+  */
+ CommandCost CmdBuildShip(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	UnitID unit_num;
+
+ 	if (!IsEngineBuildable(p1, VEH_SHIP, _current_company)) return_cmd_error(STR_ERROR_SHIP_NOT_AVAILABLE);
+Index: src/order_cmd.cpp
+===================================================================
+--- src/order_cmd.cpp	(revision 19678)
++++ src/order_cmd.cpp	(working copy)
+@@ -468,7 +468,7 @@
+ 	Order new_order(p2);
+
+ 	Vehicle *v = Vehicle::GetIfValid(veh);
+-	if (v == NULL || !CheckOwnership(v->owner)) return CMD_ERROR;
++	if (v == NULL || !v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* Check if the inserted order is to the correct destination (owner, type),
+ 	 * and has the correct flags if any */
+@@ -547,8 +547,6 @@
+ 						default: return CMD_ERROR;
+ 					}
+ 				}
+-			} else {
+-				if (!IsCompanyBuildableVehicleType(v)) return CMD_ERROR;
+ 			}
+
+ 			if (new_order.GetNonStopType() != ONSF_STOP_EVERYWHERE && v->type != VEH_TRAIN && v->type != VEH_ROAD) return CMD_ERROR;
+@@ -729,7 +727,7 @@
+
+ 	Vehicle *v = Vehicle::GetIfValid(veh_id);
+
+-	if (v == NULL || !CheckOwnership(v->owner)) return CMD_ERROR;
++	if (v == NULL || !v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* If we did not select an order, we maybe want to de-clone the orders */
+ 	if (sel_ord >= v->GetNumOrders())
+@@ -795,10 +793,7 @@
+
+ 	Vehicle *v = Vehicle::GetIfValid(veh_id);
+
+-	if (v == NULL || !CheckOwnership(v->owner) || sel_ord == v->cur_order_index ||
+-			sel_ord >= v->GetNumOrders() || v->GetNumOrders() < 2) {
+-		return CMD_ERROR;
+-	}
++	if (v == NULL || !v->IsPrimaryVehicle() || !CheckOwnership(v->owner) || sel_ord == v->cur_order_index || sel_ord >= v->GetNumOrders() || v->GetNumOrders() < 2) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+ 		v->cur_order_index = sel_ord;
+@@ -835,7 +830,7 @@
+ 	VehicleOrderID target_order = GB(p2, 16, 16);
+
+ 	Vehicle *v = Vehicle::GetIfValid(veh);
+-	if (v == NULL || !CheckOwnership(v->owner)) return CMD_ERROR;
++	if (v == NULL || !v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* Don't make senseless movements */
+ 	if (moving_order >= v->GetNumOrders() || target_order >= v->GetNumOrders() ||
+@@ -916,7 +911,7 @@
+ 	if (mof >= MOF_END) return CMD_ERROR;
+
+ 	Vehicle *v = Vehicle::GetIfValid(veh);
+-	if (v == NULL || !CheckOwnership(v->owner)) return CMD_ERROR;
++	if (v == NULL || !v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	/* Is it a valid order? */
+ 	if (sel_ord >= v->GetNumOrders()) return CMD_ERROR;
+@@ -1139,17 +1134,14 @@
+ 	VehicleID veh_dst = GB(p1,  0, 16);
+
+ 	Vehicle *dst = Vehicle::GetIfValid(veh_dst);
++	if (dst == NULL || !dst->IsPrimaryVehicle() || !CheckOwnership(dst->owner)) return CMD_ERROR;
+
+-	if (dst == NULL || !CheckOwnership(dst->owner)) return CMD_ERROR;
+-
+ 	switch (p2) {
+ 		case CO_SHARE: {
+ 			Vehicle *src = Vehicle::GetIfValid(veh_src);
+
+ 			/* Sanity checks */
+-			if (src == NULL || !CheckOwnership(src->owner) || dst->type != src->type || dst == src) {
+-				return CMD_ERROR;
+-			}
++			if (src == NULL || !src->IsPrimaryVehicle() || !CheckOwnership(src->owner) || dst->type != src->type || dst == src) return CMD_ERROR;
+
+ 			/* Trucks can't share orders with busses (and visa versa) */
+ 			if (src->type == VEH_ROAD && RoadVehicle::From(src)->IsBus() != RoadVehicle::From(dst)->IsBus()) {
+@@ -1188,9 +1180,7 @@
+ 			Vehicle *src = Vehicle::GetIfValid(veh_src);
+
+ 			/* Sanity checks */
+-			if (src == NULL || !CheckOwnership(src->owner) || dst->type != src->type || dst == src) {
+-				return CMD_ERROR;
+-			}
++			if (src == NULL || !src->IsPrimaryVehicle() || !CheckOwnership(src->owner) || dst->type != src->type || dst == src) return CMD_ERROR;
+
+ 			/* Trucks can't copy all the orders from busses (and visa versa),
+ 			 * and neither can helicopters and aircarft. */
+@@ -1263,8 +1253,10 @@
+ 	CargoID cargo = GB(p2, 0, 8);
+ 	byte subtype  = GB(p2, 8, 8);
+
++	if (cargo >= NUM_CARGO) return CMD_ERROR;
++
+ 	const Vehicle *v = Vehicle::GetIfValid(veh);
+-	if (v == NULL || !CheckOwnership(v->owner)) return CMD_ERROR;
++	if (v == NULL || !v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	Order *order = v->GetOrder(order_number);
+ 	if (order == NULL) return CMD_ERROR;
+@@ -1416,7 +1408,8 @@
+
+ 	Vehicle *v = Vehicle::GetIfValid(p1);
+ 	/* Check the vehicle type and ownership, and if the service interval and order are in range */
+-	if (v == NULL || !CheckOwnership(v->owner)) return CMD_ERROR;
++	if (v == NULL || !v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
++
+ 	if (serv_int != GetServiceIntervalClamped(serv_int, v->owner) || cur_ord >= v->GetNumOrders()) return CMD_ERROR;
+
+ 	if (flags & DC_EXEC) {
+Index: src/vehicle_cmd.cpp
+===================================================================
+--- src/vehicle_cmd.cpp	(revision 19678)
++++ src/vehicle_cmd.cpp	(working copy)
+@@ -13,6 +13,7 @@
+ #include "roadveh.h"
+ #include "news_func.h"
+ #include "airport.h"
++#include "cmd_helper.h"
+ #include "command_func.h"
+ #include "company_func.h"
+ #include "vehicle_gui.h"
+@@ -130,15 +131,17 @@
+ CommandCost CmdMassStartStopVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+ 	VehicleList list;
+-	VehicleType vehicle_type = (VehicleType)GB(p2, 0, 5);
++	VehicleType vehicle_type = (VehicleType)GB(p2, 0, 3);
+ 	bool start_stop = HasBit(p2, 5);
+ 	bool vehicle_list_window = HasBit(p2, 6);
+
++	if (!IsCompanyBuildableVehicleType(vehicle_type)) return CMD_ERROR;
++
+ 	if (vehicle_list_window) {
+ 		uint32 id = p1;
+ 		uint16 window_type = p2 & VLW_MASK;
+
+-		GenerateVehicleSortList(&list, vehicle_type, _current_company, id, window_type);
++		if (!GenerateVehicleSortList(&list, vehicle_type, _current_company, id, window_type)) return CMD_ERROR;
+ 	} else {
+ 		/* Get the list of vehicles in the depot */
+ 		BuildDepotVehicleList(vehicle_type, tile, &list, NULL);
+@@ -177,9 +180,11 @@
+ 	VehicleList list;
+
+ 	CommandCost cost(EXPENSES_NEW_VEHICLES);
+-	VehicleType vehicle_type = (VehicleType)GB(p1, 0, 8);
++	VehicleType vehicle_type = (VehicleType)GB(p1, 0, 3);
+ 	uint sell_command = GetCmdSellVeh(vehicle_type);
+
++	if (!IsCompanyBuildableVehicleType(vehicle_type)) return CMD_ERROR;
++
+ 	/* Get the list of vehicles in the depot */
+ 	BuildDepotVehicleList(vehicle_type, tile, &list, &list);
+
+@@ -205,8 +210,9 @@
+ {
+ 	VehicleList list;
+ 	CommandCost cost = CommandCost(EXPENSES_NEW_VEHICLES);
+-	VehicleType vehicle_type = (VehicleType)GB(p1, 0, 8);
++	VehicleType vehicle_type = (VehicleType)GB(p1, 0, 3);
+
++	if (!IsCompanyBuildableVehicleType(vehicle_type)) return CMD_ERROR;
+ 	if (!IsDepotTile(tile) || !IsTileOwner(tile, _current_company)) return CMD_ERROR;
+
+ 	/* Get the list of vehicles in the depot */
+@@ -392,7 +398,7 @@
+ 	uint32 build_argument = 2;
+
+ 	Vehicle *v = Vehicle::GetIfValid(p1);
+-	if (v == NULL) return CMD_ERROR;
++	if (v == NULL || !v->IsPrimaryVehicle()) return CMD_ERROR;
+ 	Vehicle *v_front = v;
+ 	Vehicle *w = NULL;
+ 	Vehicle *w_front = NULL;
+@@ -577,7 +583,7 @@
+ {
+ 	VehicleList list;
+
+-	GenerateVehicleSortList(&list, type, owner, id, vlw_flag);
++	if (!GenerateVehicleSortList(&list, type, owner, id, vlw_flag)) return CMD_ERROR;
+
+ 	/* Send all the vehicles to a depot */
+ 	for (uint i = 0; i < list.Length(); i++) {
+@@ -607,7 +613,7 @@
+ CommandCost CmdRenameVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+ 	Vehicle *v = Vehicle::GetIfValid(p1);
+-	if (v == NULL || !CheckOwnership(v->owner)) return CMD_ERROR;
++	if (v == NULL || !v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	bool reset = StrEmpty(text);
+
+@@ -638,7 +644,7 @@
+ CommandCost CmdChangeServiceInt(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+ 	Vehicle *v = Vehicle::GetIfValid(p1);
+-	if (v == NULL || !CheckOwnership(v->owner)) return CMD_ERROR;
++	if (v == NULL || !v->IsPrimaryVehicle() || !CheckOwnership(v->owner)) return CMD_ERROR;
+
+ 	uint16 serv_int = GetServiceIntervalClamped(p2, v->owner); // Double check the service interval from the user-input
+ 	if (serv_int != p2) return CMD_ERROR;
+Index: src/train_cmd.cpp
+===================================================================
+--- src/train_cmd.cpp	(revision 19678)
++++ src/train_cmd.cpp	(working copy)
+@@ -816,6 +816,7 @@
+  */
+ CommandCost CmdBuildRailVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	/* Check if the engine-type is valid (for the company) */
+ 	if (!IsEngineBuildable(p1, VEH_TRAIN, _current_company)) return_cmd_error(STR_ERROR_RAIL_VEHICLE_NOT_AVAILABLE);
+
+Index: src/tunnelbridge_cmd.cpp
+===================================================================
+--- src/tunnelbridge_cmd.cpp	(revision 19678)
++++ src/tunnelbridge_cmd.cpp	(working copy)
+@@ -210,7 +210,7 @@
+ 			break;
+
+ 		case TRANSPORT_RAIL:
+-			railtype = (RailType)GB(p2, 8, 7);
++			railtype = (RailType)GB(p2, 8, 4);
+ 			if (!ValParamRailtype(railtype)) return CMD_ERROR;
+ 			break;
+
+@@ -482,7 +482,7 @@
+
+ 	_build_tunnel_endtile = 0;
+ 	if (transport_type == TRANSPORT_RAIL) {
+-		if (!ValParamRailtype((RailType)p1)) return CMD_ERROR;
++		if (!ValParamRailtype((RailType)GB(p1, 0, 4))) return CMD_ERROR;
+ 	} else {
+ 		const RoadTypes rts = (RoadTypes)GB(p1, 0, 2);
+ 		if (!AreValidRoadTypes(rts) || !HasRoadTypesAvail(_current_company, rts)) return CMD_ERROR;
+Index: src/water_cmd.cpp
+===================================================================
+--- src/water_cmd.cpp	(revision 19678)
++++ src/water_cmd.cpp	(working copy)
+@@ -291,7 +291,7 @@
+ {
+ 	CommandCost cost(EXPENSES_CONSTRUCTION);
+
+-	if (p1 >= MapSize()) return CMD_ERROR;
++	if (p1 >= MapSize() || p2 > 2) return CMD_ERROR;
+
+ 	/* Outside of the editor you can only build canals, not oceans */
+ 	if (p2 != 0 && _game_mode != GM_EDITOR) return CMD_ERROR;
+Index: src/economy.cpp
+===================================================================
+--- src/economy.cpp	(revision 19678)
++++ src/economy.cpp	(working copy)
+@@ -1502,7 +1502,7 @@
+ CommandCost CmdBuyShareInCompany(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
+ 	CommandCost cost(EXPENSES_OTHER);
+-
++	p1 = GB(p1, 0, 8);
+ 	Company *c = Company::GetIfValid(p1);
+
+ 	/* Check if buying shares is allowed (protection against modified clients)
+@@ -1548,6 +1548,7 @@
+  */
+ CommandCost CmdSellShareInCompany(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 8);
+ 	Company *c = Company::GetIfValid(p1);
+
+ 	/* Check if selling shares is allowed (protection against modified clients)
+@@ -1583,6 +1584,7 @@
+  */
+ CommandCost CmdBuyCompany(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 8);
+ 	Company *c = Company::GetIfValid(p1);
+ 	if (c == NULL) return CMD_ERROR;
+
+Index: src/rail.cpp
+===================================================================
+--- src/rail.cpp	(revision 19678)
++++ src/rail.cpp	(working copy)
+@@ -181,7 +181,7 @@
+
+ bool ValParamRailtype(const RailType rail)
+ {
+-	return HasRailtypeAvail(_current_company, rail);
++	return rail < RAILTYPE_END && HasRailtypeAvail(_current_company, rail);
+ }
+
+ RailType GetBestRailtype(const CompanyID company)
+Index: src/roadveh_cmd.cpp
+===================================================================
+--- src/roadveh_cmd.cpp	(revision 19678)
++++ src/roadveh_cmd.cpp	(working copy)
+@@ -200,6 +200,7 @@
+  */
+ CommandCost CmdBuildRoadVeh(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsEngineBuildable(p1, VEH_ROAD, _current_company)) return_cmd_error(STR_ERROR_ROAD_VEHICLE_NOT_AVAILABLE);
+
+ 	const Engine *e = Engine::Get(p1);
+Index: src/aircraft_cmd.cpp
+===================================================================
+--- src/aircraft_cmd.cpp	(revision 19678)
++++ src/aircraft_cmd.cpp	(working copy)
+@@ -237,6 +237,7 @@
+  */
+ CommandCost CmdBuildAircraft(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+ {
++	p1 = GB(p1, 0, 16);
+ 	if (!IsEngineBuildable(p1, VEH_AIRCRAFT, _current_company)) return_cmd_error(STR_ERROR_AIRCRAFT_NOT_AVAILABLE);
+
+ 	const Engine *e = Engine::Get(p1);

--- a/_security/CVE-2010-0406.md
+++ b/_security/CVE-2010-0406.md
@@ -1,0 +1,24 @@
+---
+name: CVE-2010-0406
+description: Denial of service (server) via leaking file descriptors
+first_vulnerable: 0.3.5
+first_fixed: 1.0.1
+related_bugs:
+- 3785
+related_commits:
+- 26af87b
+patches:
+- name: For version 0.6.0 up to including 1.0.0
+  file: 0.6.0 - 1.0.0.patch
+- name: For version 0.3.5 up to including 0.5.3
+  file: 0.3.5 - 0.5.3.patch
+---
+
+Upon a client downloading the map from the server a file is allocated. If this
+download fails for any reason at the client side, e.g. lost connection or the
+player cancelling the download, a file descriptor is lost.
+
+Repeating this process enough times can cause OpenTTD to run out of file
+descriptors and as a result crash OpenTTD.
+
+The attached patches do not change network compatability at all.

--- a/_security/CVE-2010-0406/0.3.5 - 0.5.3.patch
+++ b/_security/CVE-2010-0406/0.3.5 - 0.5.3.patch
@@ -1,0 +1,36 @@
+---
+layout: security_patch
+cve: CVE-2010-0406
+first_version: 0.3.5
+last_version: 0.5.3
+---
+
+Index: network_server.c
+===================================================================
+--- network_server.c	(revision 19694)
++++ network_server.c	(revision 19695)
+@@ -322,4 +322,4 @@
+
+-	static FILE *file_pointer;
++	static FILE *file_pointer = NULL;
+ 	static uint sent_packets; // How many packets we did send succecfully last time
+
+@@ -338,6 +338,9 @@
+ 		if (SaveOrLoad(filename, SL_SAVE, AUTOSAVE_DIR) != SL_OK) usererror("network savedump failed");
+
++		if (file_pointer != NULL) fclose(file_pointer);
++
+ 		file_pointer = fopen(filename, "rb");
++		if (file_pointer == NULL) error("network savedump failed - could not open just saved dump");
++
+ 		fseek(file_pointer, 0, SEEK_END);
+-
+ 		if (ftell(file_pointer) == 0) usererror("network savedump failed - zero sized savegame?");
+@@ -382,6 +385,7 @@
+ 				 *  to send it is ready (maybe that happens like never ;)) */
+ 				cs->status = STATUS_DONE_MAP;
+ 				fclose(file_pointer);
++				file_pointer = NULL;
+
+ 				NetworkClientSocket *new_cs;
+ 				bool new_map_client = false;

--- a/_security/CVE-2010-0406/0.6.0 - 1.0.0.patch
+++ b/_security/CVE-2010-0406/0.6.0 - 1.0.0.patch
@@ -1,0 +1,39 @@
+---
+layout: security_patch
+cve: CVE-2010-0406
+first_version: 0.6.0
+last_version: 1.0.0
+---
+
+Index: src/network/network_server.cpp
+===================================================================
+--- src/network/network_server.cpp	(revision 19694)
++++ src/network/network_server.cpp	(revision 19695)
+@@ -322,7 +322,7 @@
+ 	 *    nothing
+ 	 */
+
+-	static FILE *file_pointer;
++	static FILE *file_pointer = NULL;
+ 	static uint sent_packets; // How many packets we did send succecfully last time
+
+ 	if (cs->status < STATUS_AUTHORIZED) {
+@@ -338,6 +338,9 @@
+ 		if (SaveOrLoad(filename, SL_SAVE, AUTOSAVE_DIR) != SL_OK) usererror("network savedump failed");
+
++		if (file_pointer != NULL) fclose(file_pointer);
++
+ 		file_pointer = FioFOpenFile(filename, "rb", AUTOSAVE_DIR);
++		if (file_pointer == NULL) error("network savedump failed - could not open just saved dump");
++
+ 		fseek(file_pointer, 0, SEEK_END);
+-
+ 		if (ftell(file_pointer) == 0) usererror("network savedump failed - zero sized savegame?");
+@@ -382,6 +385,7 @@
+ 				 *  to send it is ready (maybe that happens like never ;)) */
+ 				cs->status = STATUS_DONE_MAP;
+ 				fclose(file_pointer);
++				file_pointer = NULL;
+
+ 				NetworkClientSocket *new_cs;
+ 				bool new_map_client = false;

--- a/_security/CVE-2010-2534.md
+++ b/_security/CVE-2010-2534.md
@@ -1,0 +1,25 @@
+---
+name: CVE-2010-2534
+description: Denial of service (server) via infinite loop
+first_vulnerable: 1.0.1
+first_fixed: 1.0.3
+related_bugs:
+- 3909
+related_commits:
+- ed35d62
+patches:
+- name: For version 1.0.1 up to including 1.0.2
+  file: 1.0.1 - 1.0.2.patch
+---
+
+When multiple commands are queued (at the server) for execution in the next
+game tick and an client joins the server can get into an infinite loop.
+
+With the default settings triggering this bug is difficult (if not
+impossible), however the larger value of the "frame_freq" setting is easier
+it is to trigger the bug.
+
+To trigger this bug in a server there must be enough activity on the server,
+that is commands being sent to the server for execution. Furthermore the
+joining client that triggers the bug must know the server password if there
+is a server password and there must be place for the new client.

--- a/_security/CVE-2010-2534/1.0.1 - 1.0.2.patch
+++ b/_security/CVE-2010-2534/1.0.1 - 1.0.2.patch
@@ -1,0 +1,19 @@
+---
+layout: security_patch
+cve: CVE-2010-2534
+first_version: 1.0.1
+last_version: 1.0.2
+---
+
+Index: src/network/network_command.cpp
+===================================================================
+--- src/network/network_command.cpp	(revision 20035)
++++ src/network/network_command.cpp	(working copy)
+@@ -141,6 +141,7 @@
+ 	for (CommandPacket *p = _local_command_queue; p != NULL; p = p->next) {
+ 		CommandPacket c = *p;
+ 		c.callback = 0;
++		c.next = NULL;
+ 		NetworkAddCommandQueue(c, cs);
+ 	}
+ }

--- a/_security/CVE-2010-4168.md
+++ b/_security/CVE-2010-4168.md
@@ -1,0 +1,26 @@
+---
+name: CVE-2010-4168
+description: Denial of service (server/client) via invalid read
+first_vulnerable: 1.0.0
+first_fixed: 1.0.5
+related_bugs: []
+related_commits:
+- 673b371
+patches:
+- name: For version 1.0.0 up to including 1.0.4
+  file: 1.0.0 - 1.0.4.patch
+---
+
+When a client disconnects, without sending the "quit" or "client error" message,
+the server has a chance of reading and writing a just freed piece of memory. The
+chance depends on when the disconnect is noticed, whether OpenTTD can write to
+the socket, and whether there are packets from the client waiting to be
+processed. The writing can only happen while the server is sending the map.
+
+For clients there is a chance that, upon reconnect after being disconnected
+during the join process, a just freed piece of memory is read.
+
+Depending on what happens directly after freeing the memory there is a chance
+that a segmentation fault, and thus a denial of service will occur.
+
+The attached patch does not change network compatability at all. 

--- a/_security/CVE-2010-4168/1.0.0 - 1.0.4.patch
+++ b/_security/CVE-2010-4168/1.0.0 - 1.0.4.patch
@@ -1,0 +1,45 @@
+---
+layout: security_patch
+cve: CVE-2010-4168
+first_version: 1.0.0
+last_version: 1.0.4
+---
+
+Index: src/network/network_server.cpp
+===================================================================
+--- src/network/network_server.cpp	(revision 21182)
++++ src/network/network_server.cpp	(working copy)
+@@ -412,8 +412,7 @@
+ 		}
+
+ 		/* Send all packets (forced) and check if we have send it all */
+-		cs->Send_Packets();
+-		if (cs->IsPacketQueueEmpty()) {
++		if (cs->Send_Packets() && cs->IsPacketQueueEmpty()) {
+ 			/* All are sent, increase the sent_packets */
+ 			sent_packets *= 2;
+ 		} else {
+Index: src/network/network.cpp
+===================================================================
+--- src/network/network.cpp	(revision 21182)
++++ src/network/network.cpp	(working copy)
+@@ -675,7 +675,7 @@
+ 	FOR_ALL_CLIENT_SOCKETS(cs) {
+ 		if (!_network_server) {
+ 			SEND_COMMAND(PACKET_CLIENT_QUIT)();
+-			cs->Send_Packets();
++			cs->Send_Packets(true);
+ 		}
+ 		NetworkCloseClient(cs, NETWORK_RECV_STATUS_CONN_LOST);
+ 	}
+@@ -1006,9 +1006,7 @@
+ 	NetworkClientSocket *cs;
+ 	FOR_ALL_CLIENT_SOCKETS(cs) {
+ 		if (cs->writable) {
+-			cs->Send_Packets();
+-
+-			if (cs->status == STATUS_MAP) {
++			if (cs->Send_Packets() && cs->status == STATUS_MAP) {
+ 				/* This client is in the middle of a map-send, call the function for that */
+ 				SEND_COMMAND(PACKET_SERVER_MAP)(cs);
+ 			}

--- a/_security/CVE-2011-3341.md
+++ b/_security/CVE-2011-3341.md
@@ -1,0 +1,43 @@
+---
+name: CVE-2011-3341
+description: Denial of service via improperly validated commands
+first_vulnerable: 0.3.5
+first_fixed: 1.1.3
+related_bugs:
+- 4745
+related_commits:
+- 4836a6e
+patches:
+- name: For version 1.1.0 up to including 1.1.2
+  file: 1.1.0 - 1.1.2.patch
+- name: For version 1.0.1 up to including 1.0.5
+  file: 1.0.1 - 1.0.5.patch
+- name: For version 1.0.0 up to including 1.0.0
+  file: 1.0.0 - 1.0.0.patch
+- name: For version 0.7.0 up to including 0.7.5
+  file: 0.7.0 - 0.7.5.patch
+- name: For version 0.6.0 up to including 0.6.3
+  file: 0.6.0 - 0.6.3.patch
+- name: For version 0.3.5 up to including 0.5.3
+  file: 0.3.5 - 0.5.3.patch
+---
+
+In multiple places in-game commands are not properly validated that allow remote 
+attackers to cause a denial of service (crash) and possibly execute arbitrary 
+code via unspecified vectors.
+
+The bug is exploitable only in-game so the attacker must have access to the 
+server: his IP must not be banned, he must know the password if it has been set 
+and the server must not be full.
+
+The major cause of these bugs are off-by-one errors in the validation of the 
+sent commands from the clients to the server, and from the server to the client. 
+One could therefore, in theory, affect both the server and the clients of that 
+server.
+
+Two of the cases (since 0.7.0) are known to make the game state invalid, which 
+causes an eventual crash of the application via an "abort()". Two cases cause a 
+read beyond the boundaries of a (static) table (resp. since 0.3.5 and 1.0.0). 
+The last case allows changes to the game state of others that might trigger 
+invalid reads for other players if they had the autoreplace window opened (since 
+0.6.0).

--- a/_security/CVE-2011-3341/0.3.5 - 0.5.3.patch
+++ b/_security/CVE-2011-3341/0.3.5 - 0.5.3.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2011-3341
+first_version: 0.3.5
+last_version: 0.5.3
+---
+
+Index: network_data.c
+===================================================================
+--- network_data.c	(revision 22703)
++++ network_data.c	(working copy)
+@@ -494,7 +494,7 @@
+ 	_current_player = cp->player;
+ 	_cmd_text = cp->text;
+ 	/* cp->callback is unsigned. so we don't need to do lower bounds checking. */
+-	if (cp->callback > _callback_table_count) {
++	if (cp->callback >= _callback_table_count) {
+ 		DEBUG(net,0) ("[NET] Received out-of-bounds callback! (%d)", cp->callback);
+ 		cp->callback = 0;
+ 	}

--- a/_security/CVE-2011-3341/0.6.0 - 0.6.3.patch
+++ b/_security/CVE-2011-3341/0.6.0 - 0.6.3.patch
@@ -1,0 +1,33 @@
+---
+layout: security_patch
+cve: CVE-2011-3341
+first_version: 0.6.0
+last_version: 0.6.3
+---
+
+Index: src/network/network_data.cpp
+===================================================================
+--- src/network/network_data.cpp	(revision 22703)
++++ src/network/network_data.cpp	(working copy)
+@@ -96,7 +96,7 @@
+ 	_current_player = cp->player;
+ 	_cmd_text = cp->text;
+ 	/* cp->callback is unsigned. so we don't need to do lower bounds checking. */
+-	if (cp->callback > _callback_table_count) {
++	if (cp->callback >= _callback_table_count) {
+ 		DEBUG(net, 0, "Received out-of-bounds callback (%d)", cp->callback);
+ 		cp->callback = 0;
+ 	}
+Index: src/players.cpp
+===================================================================
+--- src/players.cpp	(revision 22703)
++++ src/players.cpp	(working copy)
+@@ -703,7 +703,7 @@
+ 			GroupID id_g = GB(p1, 16, 16);
+ 			CommandCost cost;
+ 
+-			if (!IsValidGroupID(id_g) && !IsAllGroupID(id_g) && !IsDefaultGroupID(id_g)) return CMD_ERROR;
++			if (IsValidGroupID(id_g) ? GetGroup(id_g)->owner != _current_company : !IsAllGroupID(id_g) && !IsDefaultGroupID(id_g)) return CMD_ERROR;
+ 			if (new_engine_type != INVALID_ENGINE) {
+ 				/* First we make sure that it's a valid type the user requested
+ 				 * check that it's an engine that is in the engine array */

--- a/_security/CVE-2011-3341/0.7.0 - 0.7.5.patch
+++ b/_security/CVE-2011-3341/0.7.0 - 0.7.5.patch
@@ -1,0 +1,50 @@
+---
+layout: security_patch
+cve: CVE-2011-3341
+first_version: 0.7.0
+last_version: 0.7.5
+---
+
+Index: src/order_cmd.cpp
+===================================================================
+--- src/order_cmd.cpp	(revision 22703)
++++ src/order_cmd.cpp	(working copy)
+@@ -541,10 +541,10 @@
+ 		case OT_CONDITIONAL: {
+ 			VehicleOrderID skip_to = new_order.GetConditionSkipToOrder();
+ 			if (skip_to != 0 && skip_to >= v->GetNumOrders()) return CMD_ERROR; // Always allow jumping to the first (even when there is no order).
+-			if (new_order.GetConditionVariable() > OCV_END) return CMD_ERROR;
++			if (new_order.GetConditionVariable() >= OCV_END) return CMD_ERROR;
+ 
+ 			OrderConditionComparator occ = new_order.GetConditionComparator();
+-			if (occ > OCC_END) return CMD_ERROR;
++			if (occ >= OCC_END) return CMD_ERROR;
+ 			switch (new_order.GetConditionVariable()) {
+ 				case OCV_REQUIRES_SERVICE:
+ 					if (occ != OCC_IS_TRUE && occ != OCC_IS_FALSE) return CMD_ERROR;
+Index: src/company_cmd.cpp
+===================================================================
+--- src/company_cmd.cpp	(revision 22703)
++++ src/company_cmd.cpp	(working copy)
+@@ -636,7 +636,7 @@
+ 			GroupID id_g = GB(p1, 16, 16);
+ 			CommandCost cost;
+ 
+-			if (!IsValidGroupID(id_g) && !IsAllGroupID(id_g) && !IsDefaultGroupID(id_g)) return CMD_ERROR;
++			if (IsValidGroupID(id_g) ? GetGroup(id_g)->owner != _current_company : !IsAllGroupID(id_g) && !IsDefaultGroupID(id_g)) return CMD_ERROR;
+ 			if (new_engine_type != INVALID_ENGINE) {
+ 				if (!CheckAutoreplaceValidity(old_engine_type, new_engine_type, _current_company)) return CMD_ERROR;
+ 
+Index: src/network/network_command.cpp
+===================================================================
+--- src/network/network_command.cpp	(revision 22703)
++++ src/network/network_command.cpp	(working copy)
+@@ -153,7 +153,7 @@
+ 	if (!IsValidCommand(cp->cmd))               return "invalid command";
+ 	if (GetCommandFlags(cp->cmd) & CMD_OFFLINE) return "offline only command";
+ 	if ((cp->cmd & CMD_FLAGS_MASK) != 0)        return "invalid command flag";
+-	if (callback > _callback_table_count)       return "invalid callback";
++	if (callback >= _callback_table_count)      return "invalid callback";
+ 
+ 	cp->callback = _callback_table[callback];
+ 	return NULL;

--- a/_security/CVE-2011-3341/1.0.0 - 1.0.0.patch
+++ b/_security/CVE-2011-3341/1.0.0 - 1.0.0.patch
@@ -1,0 +1,62 @@
+---
+layout: security_patch
+cve: CVE-2011-3341
+first_version: 1.0.0
+last_version: 1.0.0
+---
+
+Index: src/order_cmd.cpp
+===================================================================
+--- src/order_cmd.cpp	(revision 22844)
++++ src/order_cmd.cpp	(working copy)
+@@ -586,10 +586,10 @@
+ 		case OT_CONDITIONAL: {
+ 			VehicleOrderID skip_to = new_order.GetConditionSkipToOrder();
+ 			if (skip_to != 0 && skip_to >= v->GetNumOrders()) return CMD_ERROR; // Always allow jumping to the first (even when there is no order).
+-			if (new_order.GetConditionVariable() > OCV_END) return CMD_ERROR;
++			if (new_order.GetConditionVariable() >= OCV_END) return CMD_ERROR;
+ 
+ 			OrderConditionComparator occ = new_order.GetConditionComparator();
+-			if (occ > OCC_END) return CMD_ERROR;
++			if (occ >= OCC_END) return CMD_ERROR;
+ 			switch (new_order.GetConditionVariable()) {
+ 				case OCV_REQUIRES_SERVICE:
+ 					if (occ != OCC_IS_TRUE && occ != OCC_IS_FALSE) return CMD_ERROR;
+Index: src/company_cmd.cpp
+===================================================================
+--- src/company_cmd.cpp	(revision 22844)
++++ src/company_cmd.cpp	(working copy)
+@@ -668,7 +668,7 @@
+ 	GroupID id_g = GB(p1, 16, 16);
+ 	CommandCost cost;
+ 
+-	if (!Group::IsValidID(id_g) && !IsAllGroupID(id_g) && !IsDefaultGroupID(id_g)) return CMD_ERROR;
++	if (Group::IsValidID(id_g) ? Group::Get(id_g)->owner != _current_company : !IsAllGroupID(id_g) && !IsDefaultGroupID(id_g)) return CMD_ERROR;
+ 	if (!Engine::IsValidID(old_engine_type)) return CMD_ERROR;
+ 
+ 	if (new_engine_type != INVALID_ENGINE) {
+Index: src/vehicle_cmd.cpp
+===================================================================
+--- src/vehicle_cmd.cpp	(revision 22844)
++++ src/vehicle_cmd.cpp	(working copy)
+@@ -178,6 +178,7 @@
+ 
+ 	CommandCost cost(EXPENSES_NEW_VEHICLES);
+ 	VehicleType vehicle_type = (VehicleType)GB(p1, 0, 8);
++	if (!IsCompanyBuildableVehicleType(vehicle_type)) return CMD_ERROR;
+ 	uint sell_command = GetCmdSellVeh(vehicle_type);
+ 
+ 	/* Get the list of vehicles in the depot */
+Index: src/network/network_command.cpp
+===================================================================
+--- src/network/network_command.cpp	(revision 22844)
++++ src/network/network_command.cpp	(working copy)
+@@ -189,7 +189,7 @@
+ 	if (!IsValidCommand(cp->cmd))               return "invalid command";
+ 	if (GetCommandFlags(cp->cmd) & CMD_OFFLINE) return "offline only command";
+ 	if ((cp->cmd & CMD_FLAGS_MASK) != 0)        return "invalid command flag";
+-	if (callback > lengthof(_callback_table))   return "invalid callback";
++	if (callback >= lengthof(_callback_table))  return "invalid callback";
+ 
+ 	cp->callback = _callback_table[callback];
+ 	return NULL;

--- a/_security/CVE-2011-3341/1.0.1 - 1.0.5.patch
+++ b/_security/CVE-2011-3341/1.0.1 - 1.0.5.patch
@@ -1,0 +1,67 @@
+---
+layout: security_patch
+cve: CVE-2011-3341
+first_version: 1.0.1
+last_version: 1.0.5
+---
+
+Index: src/order_cmd.cpp
+===================================================================
+--- src/order_cmd.cpp	(revision 22703)
++++ src/order_cmd.cpp	(working copy)
+@@ -585,10 +585,10 @@
+ 		case OT_CONDITIONAL: {
+ 			VehicleOrderID skip_to = new_order.GetConditionSkipToOrder();
+ 			if (skip_to != 0 && skip_to >= v->GetNumOrders()) return CMD_ERROR; // Always allow jumping to the first (even when there is no order).
+-			if (new_order.GetConditionVariable() > OCV_END) return CMD_ERROR;
++			if (new_order.GetConditionVariable() >= OCV_END) return CMD_ERROR;
+ 
+ 			OrderConditionComparator occ = new_order.GetConditionComparator();
+-			if (occ > OCC_END) return CMD_ERROR;
++			if (occ >= OCC_END) return CMD_ERROR;
+ 			switch (new_order.GetConditionVariable()) {
+ 				case OCV_REQUIRES_SERVICE:
+ 					if (occ != OCC_IS_TRUE && occ != OCC_IS_FALSE) return CMD_ERROR;
+Index: src/company_cmd.cpp
+===================================================================
+--- src/company_cmd.cpp	(revision 22703)
++++ src/company_cmd.cpp	(working copy)
+@@ -686,7 +686,7 @@
+ 	GroupID id_g = GB(p1, 16, 16);
+ 	CommandCost cost;
+ 
+-	if (!Group::IsValidID(id_g) && !IsAllGroupID(id_g) && !IsDefaultGroupID(id_g)) return CMD_ERROR;
++	if (Group::IsValidID(id_g) ? Group::Get(id_g)->owner != _current_company : !IsAllGroupID(id_g) && !IsDefaultGroupID(id_g)) return CMD_ERROR;
+ 	if (!Engine::IsValidID(old_engine_type)) return CMD_ERROR;
+ 
+ 	if (new_engine_type != INVALID_ENGINE) {
+Index: src/vehicle_cmd.cpp
+===================================================================
+--- src/vehicle_cmd.cpp	(revision 22703)
++++ src/vehicle_cmd.cpp	(working copy)
+@@ -181,10 +181,11 @@
+ 
+ 	CommandCost cost(EXPENSES_NEW_VEHICLES);
+ 	VehicleType vehicle_type = Extract<VehicleType, 0, 3>(p1);
+-	uint sell_command = GetCmdSellVeh(vehicle_type);
+ 
+ 	if (!IsCompanyBuildableVehicleType(vehicle_type)) return CMD_ERROR;
+ 
++	uint sell_command = GetCmdSellVeh(vehicle_type);
++
+ 	/* Get the list of vehicles in the depot */
+ 	BuildDepotVehicleList(vehicle_type, tile, &list, &list);
+ 
+Index: src/network/network_command.cpp
+===================================================================
+--- src/network/network_command.cpp	(revision 22703)
++++ src/network/network_command.cpp	(working copy)
+@@ -208,7 +208,7 @@
+ 	if (!IsValidCommand(cp->cmd))               return "invalid command";
+ 	if (GetCommandFlags(cp->cmd) & CMD_OFFLINE) return "offline only command";
+ 	if ((cp->cmd & CMD_FLAGS_MASK) != 0)        return "invalid command flag";
+-	if (callback > lengthof(_callback_table))   return "invalid callback";
++	if (callback >= lengthof(_callback_table))  return "invalid callback";
+ 
+ 	cp->callback = _callback_table[callback];
+ 	return NULL;

--- a/_security/CVE-2011-3341/1.1.0 - 1.1.2.patch
+++ b/_security/CVE-2011-3341/1.1.0 - 1.1.2.patch
@@ -1,0 +1,67 @@
+---
+layout: security_patch
+cve: CVE-2011-3341
+first_version: 1.1.0
+last_version: 1.1.2
+---
+
+Index: src/order_cmd.cpp
+===================================================================
+--- src/order_cmd.cpp	(revision 22749)
++++ src/order_cmd.cpp	(working copy)
+@@ -727,10 +727,10 @@
+ 		case OT_CONDITIONAL: {
+ 			VehicleOrderID skip_to = new_order.GetConditionSkipToOrder();
+ 			if (skip_to != 0 && skip_to >= v->GetNumOrders()) return CMD_ERROR; // Always allow jumping to the first (even when there is no order).
+-			if (new_order.GetConditionVariable() > OCV_END) return CMD_ERROR;
++			if (new_order.GetConditionVariable() >= OCV_END) return CMD_ERROR;
+ 
+ 			OrderConditionComparator occ = new_order.GetConditionComparator();
+-			if (occ > OCC_END) return CMD_ERROR;
++			if (occ >= OCC_END) return CMD_ERROR;
+ 			switch (new_order.GetConditionVariable()) {
+ 				case OCV_REQUIRES_SERVICE:
+ 					if (occ != OCC_IS_TRUE && occ != OCC_IS_FALSE) return CMD_ERROR;
+Index: src/vehicle_cmd.cpp
+===================================================================
+--- src/vehicle_cmd.cpp	(revision 22749)
++++ src/vehicle_cmd.cpp	(working copy)
+@@ -517,10 +517,11 @@
+ 
+ 	CommandCost cost(EXPENSES_NEW_VEHICLES);
+ 	VehicleType vehicle_type = Extract<VehicleType, 0, 3>(p1);
+-	uint sell_command = GetCmdSellVeh(vehicle_type);
+ 
+ 	if (!IsCompanyBuildableVehicleType(vehicle_type)) return CMD_ERROR;
+ 
++	uint sell_command = GetCmdSellVeh(vehicle_type);
++
+ 	/* Get the list of vehicles in the depot */
+ 	BuildDepotVehicleList(vehicle_type, tile, &list, &list);
+ 
+Index: src/network/network_command.cpp
+===================================================================
+--- src/network/network_command.cpp	(revision 22749)
++++ src/network/network_command.cpp	(working copy)
+@@ -307,7 +307,7 @@
+ 	if (!IsValidCommand(cp->cmd))               return "invalid command";
+ 	if (GetCommandFlags(cp->cmd) & CMD_OFFLINE) return "offline only command";
+ 	if ((cp->cmd & CMD_FLAGS_MASK) != 0)        return "invalid command flag";
+-	if (callback > lengthof(_callback_table))   return "invalid callback";
++	if (callback >= lengthof(_callback_table))  return "invalid callback";
+ 
+ 	cp->callback = _callback_table[callback];
+ 	return NULL;
+Index: src/autoreplace_cmd.cpp
+===================================================================
+--- src/autoreplace_cmd.cpp	(revision 22749)
++++ src/autoreplace_cmd.cpp	(working copy)
+@@ -731,7 +731,7 @@
+ 	GroupID id_g = GB(p1, 16, 16);
+ 	CommandCost cost;
+ 
+-	if (!Group::IsValidID(id_g) && !IsAllGroupID(id_g) && !IsDefaultGroupID(id_g)) return CMD_ERROR;
++	if (Group::IsValidID(id_g) ? Group::Get(id_g)->owner != _current_company : !IsAllGroupID(id_g) && !IsDefaultGroupID(id_g)) return CMD_ERROR;
+ 	if (!Engine::IsValidID(old_engine_type)) return CMD_ERROR;
+ 
+ 	if (new_engine_type != INVALID_ENGINE) {

--- a/_security/CVE-2011-3342.md
+++ b/_security/CVE-2011-3342.md
@@ -1,0 +1,42 @@
+---
+name: CVE-2011-3342
+description: Buffer overflows in savegame loading
+first_vulnerable: 0.1.0
+first_fixed: 1.1.3
+related_bugs:
+- 4748
+- 4717
+related_commits:
+- 81074e0
+- ef09794
+patches:
+- name: For version 1.1.2 up to including 1.1.2
+  file: 1.1.2 - 1.1.2.patch
+- name: For version 1.1.0 up to including 1.1.1
+  file: 1.1.0 - 1.1.1.patch
+- name: For version 1.0.5 up to including 1.0.5
+  file: 1.0.5 - 1.0.5.patch
+- name: For version 0.7.0 up to including 0.7.5
+  file: 0.7.0 - 0.7.5.patch
+- name: For version 0.6.0 up to including 0.6.3
+  file: 0.6.0 - 0.6.3.patch
+- name: For version 0.5.0 up to including 0.5.3
+  file: 0.5.0 - 0.5.3.patch
+- name: For version 1.0.0 up to including 1.0.4
+  file: 1.0.0 - 1.0.4.patch
+---
+
+In multiple places indices in savegames are not properly validated that allow 
+(remote) attackers to cause a denial of service (crash) and possibly execute 
+arbitrary code via unspecified vectors.
+
+The bug is exploitable by passing someone a modified savegame, be it via a file
+sharing site, or by running a server. In case of the server the user only has
+to be able to login into the server, which is easy to accomplish: set no server
+password and do not ban anyone. Then upon joining the server the savegame
+will be downloaded and subsequently loaded.
+
+Note that versions before 0.5.0 are vulnerable as well. However, these versions
+are over five years old and not supported anymore. Therefore no patches for
+earlier versions are provided. Before 0.3.5 it is not possible to exploit this
+bug via the internet as multiplayer over internet did not exist yet.

--- a/_security/CVE-2011-3342/0.5.0 - 0.5.3.patch
+++ b/_security/CVE-2011-3342/0.5.0 - 0.5.3.patch
@@ -1,0 +1,73 @@
+---
+layout: security_patch
+cve: CVE-2011-3342
+first_version: 0.5.0
+last_version: 0.5.3
+---
+
+Index: players.c
+===================================================================
+--- players.c	(revision 22703)
++++ players.c	(working copy)
+@@ -1298,6 +1298,7 @@
+ 	SlObject(&p->cur_economy, _player_economy_desc);
+ 
+ 	// Write old economy entries.
++	if (p->num_valid_stat_ent > lengthof(p->old_economy)) SlErrorCorrupt("Too many old economy entries");
+ 	for (i = 0; i < p->num_valid_stat_ent; i++) {
+ 		SlObject(&p->old_economy[i], _player_economy_desc);
+ 	}
+Index: misc.c
+===================================================================
+--- misc.c	(revision 22703)
++++ misc.c	(working copy)
+@@ -299,7 +299,12 @@
+ 	int index;
+ 
+ 	while ((index = SlIterateArray()) != -1) {
++		if (index >= 512) SlErrorCorrupt("Invalid old name index");
++		if (SlGetFieldLength() > 32) SlErrorCorrupt("Invalid old name length");
++
+ 		SlArray(_name_array[index],SlGetFieldLength(),SLE_UINT8);
++		/* Make sure the name is null terminated */
++		_name_array[index][31] = '\0';
+ 	}
+ }
+ 
+@@ -606,6 +611,8 @@
+ 	Cheat* cht = (Cheat*)&_cheats;
+ 	uint count = SlGetFieldLength() / 2;
+ 	uint i;
++	/* Cannot use lengthof because _cheats is of type Cheats, not Cheat */
++	if (count > sizeof(_cheats) / sizeof(Cheat)) SlErrorCorrupt("Too many cheat values");
+ 
+ 	for (i = 0; i < count; i++) {
+ 		cht[i].been_used = SlReadByte();
+Index: saveload.c
+===================================================================
+--- saveload.c	(revision 22703)
++++ saveload.c	(working copy)
+@@ -143,6 +143,11 @@
+ 	longjmp(_sl.excpt, 0);
+ }
+ 
++void SlErrorCorrupt(const char *message)
++{
++	SlError(message);
++}
++
+ /** Read in a single byte from file. If the temporary buffer is full,
+  * flush it to its final destination
+  * @return return the read byte from file
+Index: saveload.h
+===================================================================
+--- saveload.h	(revision 22703)
++++ saveload.h	(working copy)
+@@ -33,6 +33,7 @@
+ 	uint32 flags;
+ } ChunkHandler;
+ 
++NORETURN void SlErrorCorrupt(const char *message);
+ typedef struct {
+ 	byte null;
+ } NullStruct;

--- a/_security/CVE-2011-3342/0.6.0 - 0.6.3.patch
+++ b/_security/CVE-2011-3342/0.6.0 - 0.6.3.patch
@@ -1,0 +1,73 @@
+---
+layout: security_patch
+cve: CVE-2011-3342
+first_version: 0.6.0
+last_version: 0.6.3
+---
+
+Index: src/saveload.cpp
+===================================================================
+--- src/saveload.cpp	(revision 22703)
++++ src/saveload.cpp	(working copy)
+@@ -87,6 +87,11 @@
+ 	throw std::exception();
+ }
+ 
++void SlErrorCorrupt(const char *message)
++{
++	SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_SAVEGAME, message);
++}
++
+ /**
+  * Fill the input buffer by reading from the file with the given reader
+  */
+Index: src/misc.cpp
+===================================================================
+--- src/misc.cpp	(revision 22703)
++++ src/misc.cpp	(working copy)
+@@ -189,7 +189,12 @@
+ 	int index;
+ 
+ 	while ((index = SlIterateArray()) != -1) {
++		if (index >= 512) SlErrorCorrupt("Invalid old name index");
++		if (SlGetFieldLength() > 32) SlErrorCorrupt("Invalid old name length");
++
+ 		SlArray(_name_array[index], SlGetFieldLength(), SLE_UINT8);
++		/* Make sure the name is null terminated */
++		_name_array[index][31] = '\0';
+ 	}
+ }
+ 
+@@ -483,6 +488,8 @@
+ 	Cheat* cht = (Cheat*)&_cheats;
+ 	uint count = SlGetFieldLength() / 2;
+ 	uint i;
++	/* Cannot use lengthof because _cheats is of type Cheats, not Cheat */
++	if (count > sizeof(_cheats) / sizeof(Cheat)) SlErrorCorrupt("Too many cheat values");
+ 
+ 	for (i = 0; i < count; i++) {
+ 		cht[i].been_used = (SlReadByte() != 0);
+Index: src/players.cpp
+===================================================================
+--- src/players.cpp	(revision 22703)
++++ src/players.cpp	(working copy)
+@@ -1202,6 +1202,7 @@
+ 	SlObject(&p->cur_economy, _player_economy_desc);
+ 
+ 	/* Write old economy entries. */
++	if (p->num_valid_stat_ent > lengthof(p->old_economy)) SlErrorCorrupt("Too many old economy entries");
+ 	for (i = 0; i < p->num_valid_stat_ent; i++) {
+ 		SlObject(&p->old_economy[i], _player_economy_desc);
+ 	}
+Index: src/saveload.h
+===================================================================
+--- src/saveload.h	(revision 22703)
++++ src/saveload.h	(working copy)
+@@ -33,6 +33,7 @@
+ SaveOrLoadResult SaveOrLoad(const char *filename, int mode, Subdirectory sb);
+ void WaitTillSaved();
+ void DoExitSave();
++NORETURN void SlErrorCorrupt(const char *message);
+ 
+ 
+ typedef void ChunkSaveLoadProc();

--- a/_security/CVE-2011-3342/0.7.0 - 0.7.5.patch
+++ b/_security/CVE-2011-3342/0.7.0 - 0.7.5.patch
@@ -1,0 +1,90 @@
+---
+layout: security_patch
+cve: CVE-2011-3342
+first_version: 0.7.0
+last_version: 0.7.5
+---
+
+Index: src/saveload/saveload.cpp
+===================================================================
+--- src/saveload/saveload.cpp	(revision 22703)
++++ src/saveload/saveload.cpp	(working copy)
+@@ -98,6 +98,11 @@
+ 	throw std::exception();
+ }
+ 
++void SlErrorCorrupt(const char *message)
++{
++	SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_SAVEGAME, message);
++}
++
+ typedef void (*AsyncSaveFinishProc)();
+ static AsyncSaveFinishProc _async_save_finish = NULL;
+ static ThreadObject *_save_thread;
+Index: src/saveload/saveload.h
+===================================================================
+--- src/saveload/saveload.h	(revision 22703)
++++ src/saveload/saveload.h	(working copy)
+@@ -43,6 +43,7 @@
+ SaveOrLoadResult SaveOrLoad(const char *filename, int mode, Subdirectory sb);
+ void WaitTillSaved();
+ void DoExitSave();
++NORETURN void SlErrorCorrupt(const char *message);
+ 
+ 
+ typedef void ChunkSaveLoadProc();
+Index: src/saveload/company_sl.cpp
+===================================================================
+--- src/saveload/company_sl.cpp	(revision 22703)
++++ src/saveload/company_sl.cpp	(working copy)
+@@ -233,6 +233,7 @@
+ 	SlObject(&c->cur_economy, _company_economy_desc);
+ 
+ 	/* Write old economy entries. */
++	if (c->num_valid_stat_ent > lengthof(c->old_economy)) SlErrorCorrupt("Too many old economy entries");
+ 	for (i = 0; i < c->num_valid_stat_ent; i++) {
+ 		SlObject(&c->old_economy[i], _company_economy_desc);
+ 	}
+Index: src/saveload/cheat_sl.cpp
+===================================================================
+--- src/saveload/cheat_sl.cpp	(revision 22703)
++++ src/saveload/cheat_sl.cpp	(working copy)
+@@ -25,6 +25,8 @@
+ {
+ 	Cheat *cht = (Cheat*)&_cheats;
+ 	size_t count = SlGetFieldLength() / 2;
++	/* Cannot use lengthof because _cheats is of type Cheats, not Cheat */
++	if (count > sizeof(_cheats) / sizeof(Cheat)) SlErrorCorrupt("Too many cheat values");
+ 
+ 	for (uint i = 0; i < count; i++) {
+ 		cht[i].been_used = (SlReadByte() != 0);
+Index: src/saveload/ai_sl.cpp
+===================================================================
+--- src/saveload/ai_sl.cpp	(revision 22703)
++++ src/saveload/ai_sl.cpp	(working copy)
+@@ -55,6 +55,8 @@
+ 
+ 	CompanyID index;
+ 	while ((index = (CompanyID)SlIterateArray()) != (CompanyID)-1) {
++		if (index >= MAX_COMPANIES) SlErrorCorrupt("Too many AI configs");
++
+ 		_ai_saveload_version = -1;
+ 		SlObject(NULL, _ai_company);
+ 
+Index: src/saveload/strings_sl.cpp
+===================================================================
+--- src/saveload/strings_sl.cpp	(revision 22703)
++++ src/saveload/strings_sl.cpp	(working copy)
+@@ -114,7 +114,12 @@
+ 	int index;
+ 
+ 	while ((index = SlIterateArray()) != -1) {
++		if (index >= 512) SlErrorCorrupt("Invalid old name index");
++		if (SlGetFieldLength() > 32) SlErrorCorrupt("Invalid old name length");
++
+ 		SlArray(&_old_name_array[32 * index], SlGetFieldLength(), SLE_UINT8);
++		/* Make sure the old name is null terminated */
++		_old_name_array[32 * index + 31] = '\0';
+ 	}
+ }
+ 

--- a/_security/CVE-2011-3342/1.0.0 - 1.0.4.patch
+++ b/_security/CVE-2011-3342/1.0.0 - 1.0.4.patch
@@ -1,0 +1,90 @@
+---
+layout: security_patch
+cve: CVE-2011-3342
+first_version: 1.0.0
+last_version: 1.0.4
+---
+
+Index: src/saveload/saveload.cpp
+===================================================================
+--- src/saveload/saveload.cpp	(revision 20804)
++++ src/saveload/saveload.cpp	(working copy)
+@@ -203,6 +203,11 @@
+ 	throw std::exception();
+ }
+ 
++void SlErrorCorrupt(const char *message)
++{
++	SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_SAVEGAME, message);
++}
++
+ typedef void (*AsyncSaveFinishProc)();
+ static AsyncSaveFinishProc _async_save_finish = NULL;
+ static ThreadObject *_save_thread;
+Index: src/saveload/company_sl.cpp
+===================================================================
+--- src/saveload/company_sl.cpp	(revision 20804)
++++ src/saveload/company_sl.cpp	(working copy)
+@@ -247,6 +247,7 @@
+ 	SlObject(&c->cur_economy, _company_economy_desc);
+ 
+ 	/* Write old economy entries. */
++	if (c->num_valid_stat_ent > lengthof(c->old_economy)) SlErrorCorrupt("Too many old economy entries");
+ 	for (i = 0; i < c->num_valid_stat_ent; i++) {
+ 		SlObject(&c->old_economy[i], _company_economy_desc);
+ 	}
+Index: src/saveload/cheat_sl.cpp
+===================================================================
+--- src/saveload/cheat_sl.cpp	(revision 20804)
++++ src/saveload/cheat_sl.cpp	(working copy)
+@@ -32,6 +32,8 @@
+ {
+ 	Cheat *cht = (Cheat*)&_cheats;
+ 	size_t count = SlGetFieldLength() / 2;
++	/* Cannot use lengthof because _cheats is of type Cheats, not Cheat */
++	if (count > sizeof(_cheats) / sizeof(Cheat)) SlErrorCorrupt("Too many cheat values");
+ 
+ 	for (uint i = 0; i < count; i++) {
+ 		cht[i].been_used = (SlReadByte() != 0);
+Index: src/saveload/strings_sl.cpp
+===================================================================
+--- src/saveload/strings_sl.cpp	(revision 20804)
++++ src/saveload/strings_sl.cpp	(working copy)
+@@ -120,7 +120,12 @@
+ 	int index;
+ 
+ 	while ((index = SlIterateArray()) != -1) {
++		if (index >= 512) SlErrorCorrupt("Invalid old name index");
++		if (SlGetFieldLength() > 32) SlErrorCorrupt("Invalid old name length");
++
+ 		SlArray(&_old_name_array[32 * index], SlGetFieldLength(), SLE_UINT8);
++		/* Make sure the old name is null terminated */
++		_old_name_array[32 * index + 31] = '\0';
+ 	}
+ }
+ 
+Index: src/saveload/saveload.h
+===================================================================
+--- src/saveload/saveload.h	(revision 20804)
++++ src/saveload/saveload.h	(working copy)
+@@ -50,6 +50,7 @@
+ SaveOrLoadResult SaveOrLoad(const char *filename, int mode, Subdirectory sb, bool threaded = true);
+ void WaitTillSaved();
+ void DoExitSave();
++NORETURN void SlErrorCorrupt(const char *message);
+ 
+ 
+ typedef void ChunkSaveLoadProc();
+Index: src/saveload/ai_sl.cpp
+===================================================================
+--- src/saveload/ai_sl.cpp	(revision 20804)
++++ src/saveload/ai_sl.cpp	(working copy)
+@@ -66,6 +66,8 @@
+ 
+ 	CompanyID index;
+ 	while ((index = (CompanyID)SlIterateArray()) != (CompanyID)-1) {
++		if (index >= MAX_COMPANIES) SlErrorCorrupt("Too many AI configs");
++
+ 		_ai_saveload_version = -1;
+ 		SlObject(NULL, _ai_company);
+ 

--- a/_security/CVE-2011-3342/1.0.5 - 1.0.5.patch
+++ b/_security/CVE-2011-3342/1.0.5 - 1.0.5.patch
@@ -1,0 +1,62 @@
+---
+layout: security_patch
+cve: CVE-2011-3342
+first_version: 1.0.5
+last_version: 1.0.5
+---
+
+Index: src/saveload/company_sl.cpp
+===================================================================
+--- src/saveload/company_sl.cpp	(revision 22703)
++++ src/saveload/company_sl.cpp	(working copy)
+@@ -247,6 +247,7 @@
+ 	SlObject(&c->cur_economy, _company_economy_desc);
+ 
+ 	/* Write old economy entries. */
++	if (c->num_valid_stat_ent > lengthof(c->old_economy)) SlErrorCorrupt("Too many old economy entries");
+ 	for (i = 0; i < c->num_valid_stat_ent; i++) {
+ 		SlObject(&c->old_economy[i], _company_economy_desc);
+ 	}
+Index: src/saveload/cheat_sl.cpp
+===================================================================
+--- src/saveload/cheat_sl.cpp	(revision 22703)
++++ src/saveload/cheat_sl.cpp	(working copy)
+@@ -32,6 +32,8 @@
+ {
+ 	Cheat *cht = (Cheat*)&_cheats;
+ 	size_t count = SlGetFieldLength() / 2;
++	/* Cannot use lengthof because _cheats is of type Cheats, not Cheat */
++	if (count > sizeof(_cheats) / sizeof(Cheat)) SlErrorCorrupt("Too many cheat values");
+ 
+ 	for (uint i = 0; i < count; i++) {
+ 		cht[i].been_used = (SlReadByte() != 0);
+Index: src/saveload/strings_sl.cpp
+===================================================================
+--- src/saveload/strings_sl.cpp	(revision 22703)
++++ src/saveload/strings_sl.cpp	(working copy)
+@@ -120,7 +120,12 @@
+ 	int index;
+ 
+ 	while ((index = SlIterateArray()) != -1) {
++		if (index >= 512) SlErrorCorrupt("Invalid old name index");
++		if (SlGetFieldLength() > 32) SlErrorCorrupt("Invalid old name length");
++
+ 		SlArray(&_old_name_array[32 * index], SlGetFieldLength(), SLE_UINT8);
++		/* Make sure the old name is null terminated */
++		_old_name_array[32 * index + 31] = '\0';
+ 	}
+ }
+ 
+Index: src/saveload/ai_sl.cpp
+===================================================================
+--- src/saveload/ai_sl.cpp	(revision 22703)
++++ src/saveload/ai_sl.cpp	(working copy)
+@@ -66,6 +66,8 @@
+ 
+ 	CompanyID index;
+ 	while ((index = (CompanyID)SlIterateArray()) != (CompanyID)-1) {
++		if (index >= MAX_COMPANIES) SlErrorCorrupt("Too many AI configs");
++
+ 		_ai_saveload_version = -1;
+ 		SlObject(NULL, _ai_company);
+ 

--- a/_security/CVE-2011-3342/1.1.0 - 1.1.1.patch
+++ b/_security/CVE-2011-3342/1.1.0 - 1.1.1.patch
@@ -1,0 +1,62 @@
+---
+layout: security_patch
+cve: CVE-2011-3342
+first_version: 1.1.0
+last_version: 1.1.1
+---
+
+Index: src/saveload/company_sl.cpp
+===================================================================
+--- src/saveload/company_sl.cpp	(revision 22703)
++++ src/saveload/company_sl.cpp	(working copy)
+@@ -283,6 +283,7 @@
+ 	SlObject(&cprops->cur_economy, _company_economy_desc);
+ 
+ 	/* Write old economy entries. */
++	if (cprops->num_valid_stat_ent > lengthof(cprops->old_economy)) SlErrorCorrupt("Too many old economy entries");
+ 	for (i = 0; i < cprops->num_valid_stat_ent; i++) {
+ 		SlObject(&cprops->old_economy[i], _company_economy_desc);
+ 	}
+Index: src/saveload/cheat_sl.cpp
+===================================================================
+--- src/saveload/cheat_sl.cpp	(revision 22703)
++++ src/saveload/cheat_sl.cpp	(working copy)
+@@ -32,6 +32,8 @@
+ {
+ 	Cheat *cht = (Cheat*)&_cheats;
+ 	size_t count = SlGetFieldLength() / 2;
++	/* Cannot use lengthof because _cheats is of type Cheats, not Cheat */
++	if (count > sizeof(_cheats) / sizeof(Cheat)) SlErrorCorrupt("Too many cheat values");
+ 
+ 	for (uint i = 0; i < count; i++) {
+ 		cht[i].been_used = (SlReadByte() != 0);
+Index: src/saveload/strings_sl.cpp
+===================================================================
+--- src/saveload/strings_sl.cpp	(revision 22703)
++++ src/saveload/strings_sl.cpp	(working copy)
+@@ -120,7 +120,12 @@
+ 	int index;
+ 
+ 	while ((index = SlIterateArray()) != -1) {
++		if (index >= 512) SlErrorCorrupt("Invalid old name index");
++		if (SlGetFieldLength() > 32) SlErrorCorrupt("Invalid old name length");
++
+ 		SlArray(&_old_name_array[32 * index], SlGetFieldLength(), SLE_UINT8);
++		/* Make sure the old name is null terminated */
++		_old_name_array[32 * index + 31] = '\0';
+ 	}
+ }
+ 
+Index: src/saveload/ai_sl.cpp
+===================================================================
+--- src/saveload/ai_sl.cpp	(revision 22703)
++++ src/saveload/ai_sl.cpp	(working copy)
+@@ -66,6 +66,8 @@
+ 
+ 	CompanyID index;
+ 	while ((index = (CompanyID)SlIterateArray()) != (CompanyID)-1) {
++		if (index >= MAX_COMPANIES) SlErrorCorrupt("Too many AI configs");
++
+ 		_ai_saveload_version = -1;
+ 		SlObject(NULL, _ai_company);
+ 

--- a/_security/CVE-2011-3342/1.1.2 - 1.1.2.patch
+++ b/_security/CVE-2011-3342/1.1.2 - 1.1.2.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2011-3342
+first_version: 1.1.2
+last_version: 1.1.2
+---
+
+Index: src/saveload/ai_sl.cpp
+===================================================================
+--- src/saveload/ai_sl.cpp	(revision 22844)
++++ src/saveload/ai_sl.cpp	(working copy)
+@@ -66,6 +66,8 @@
+ 
+ 	CompanyID index;
+ 	while ((index = (CompanyID)SlIterateArray()) != (CompanyID)-1) {
++		if (index >= MAX_COMPANIES) SlErrorCorrupt("Too many AI configs");
++
+ 		_ai_saveload_version = -1;
+ 		SlObject(NULL, _ai_company);
+ 

--- a/_security/CVE-2011-3343.md
+++ b/_security/CVE-2011-3343.md
@@ -1,0 +1,47 @@
+---
+name: CVE-2011-3343
+description: Multiple buffer overflows in validation of external data
+first_vulnerable: 0.1.0
+first_fixed: 1.1.3
+related_bugs:
+- 4746
+- 4747
+related_commits:
+- 6c7cbb1
+- 65637d8
+- 73624ab
+patches:
+- name: For version 0.3.1 up to including 0.4.0.1
+  file: 0.3.1 - 0.4.0.1.patch
+- name: For version 0.4.5 up to including 0.4.8
+  file: 0.4.5 - 0.4.8.patch
+- name: For version 0.5.0 up to including 0.5.3
+  file: 0.5.0 - 0.5.3.patch
+- name: For version 0.6.0 up to including 0.6.3
+  file: 0.6.0 - 0.6.3.patch
+- name: For version 0.7.0 up to including 0.7.5
+  file: 0.7.0 - 0.7.5.patch
+- name: For version 1.0.0 up to including 1.0.5
+  file: 1.0.0 - 1.0.5.patch
+- name: For version 1.1.0 up to including 1.1.2
+  file: 1.1.0 - 1.1.2.patch
+---
+
+In multiple places external data isn't properly checked before allocating
+memory, which could lead to buffer overflows and arbitrary code execution.
+
+These bugs are only exploitable locally by providing OpenTTD with
+invalid/manipulated images, sounds or fonts. This means an attacker
+either needs local access or has to trick an user into loading a
+manipulated image into OpenTTD. This is especially a concern with
+BMP files loaded as heightmaps.
+
+All except one vulnerability are caused by improper validation of input
+data prior to allocating memory buffers. It is possible to force allocation
+of a too small buffer and thus out-of-bounds writes by causing an integer
+overflow. Additionally in RLE-compressed BMP images, it is possible to
+write arbitrary data outside the allocated buffer.
+
+No patch for releases before 0.3.1 is provided, as this versions are
+unsupported since a long time and would require larger changes not worth
+the effort.

--- a/_security/CVE-2011-3343/0.3.1 - 0.4.0.1.patch
+++ b/_security/CVE-2011-3343/0.3.1 - 0.4.0.1.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2011-3343
+first_version: 0.3.1
+last_version: 0.4.0.1
+---
+
+diff --git sound.c sound.c
+index 4d87d8f..cec54e6 100644
+--- sound.c
++++ sound.c
+@@ -92,7 +92,7 @@ static bool SetBankSource(MixerChannel *mc, uint bank)
+ 	int8 *mem;
+ 	uint i;
+ 
+-	if (fe->file_size == 0)
++	if (fe->file_size == 0 || fe->file_size > ((size_t)-1) - 2)
+ 		return false;
+ 
+ 	mem = malloc(fe->file_size); /* XXX unchecked malloc */

--- a/_security/CVE-2011-3343/0.4.5 - 0.4.8.patch
+++ b/_security/CVE-2011-3343/0.4.5 - 0.4.8.patch
@@ -1,0 +1,21 @@
+---
+layout: security_patch
+cve: CVE-2011-3343
+first_version: 0.4.5
+last_version: 0.4.8
+---
+
+diff --git sound.c sound.c
+index 4e3a463..1bd1616 100644
+--- sound.c
++++ sound.c
+@@ -109,7 +109,8 @@ static bool SetBankSource(MixerChannel *mc, uint bank)
+ 	if (bank >= _file_count) return false;
+ 	fe = &_files[bank];
+ 
+-	if (fe->file_size == 0) return false;
++	/* Check for valid sound size. */
++	if (fe->file_size == 0 || fe->file_size > ((size_t)-1) - 2) return false;
+ 
+ 	mem = malloc(fe->file_size);
+ 	if (mem == NULL) return false;

--- a/_security/CVE-2011-3343/0.5.0 - 0.5.3.patch
+++ b/_security/CVE-2011-3343/0.5.0 - 0.5.3.patch
@@ -1,0 +1,131 @@
+---
+layout: security_patch
+cve: CVE-2011-3343
+first_version: 0.5.0
+last_version: 0.5.3
+---
+
+diff --git bmp.c bmp.c
+index c2bd912..d9fa3ed 100644
+--- bmp.c
++++ bmp.c
+@@ -133,6 +133,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			switch (c) {
+ 			case 0: // end of line
+ 				x = 0;
++				if (y == 0) return false;
+ 				pixel = &data->bitmap[--y * info->width];
+ 				break;
+ 			case 1: // end of bitmap
+@@ -143,7 +144,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			case 2: // delta
+ 				x += ReadByte(buffer);
+ 				i = ReadByte(buffer);
+-				if (x >= info->width || (y == 0 && i > 0)) return false;
++				if (x >= info->width || i > y) return false;
+ 				y -= i;
+ 				pixel = &data->bitmap[y * info->width + x];
+ 				break;
+@@ -216,6 +217,7 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			switch (c) {
+ 			case 0: // end of line
+ 				x = 0;
++				if (y == 0) return false;
+ 				pixel = &data->bitmap[--y * info->width];
+ 				break;
+ 			case 1: // end of bitmap
+@@ -226,13 +228,16 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			case 2: // delta
+ 				x += ReadByte(buffer);
+ 				i = ReadByte(buffer);
+-				if (x >= info->width || (y == 0 && i > 0)) return false;
++				if (x >= info->width || i > y) return false;
+ 				y -= i;
+ 				pixel = &data->bitmap[y * info->width + x];
+ 				break;
+ 			default: // uncompressed
+-				if ((x += c) > info->width) return false;
+-				for (i = 0; i < c; i++) *pixel++ = ReadByte(buffer);
++				for (i = 0; i < c; i++) {
++					if (EndOfBuffer(buffer) || x >= info->width) return false;
++					*pixel++ = ReadByte(buffer);
++					x++;
++				}
+ 				/* Padding for 16 bit align */
+ 				SkipBytes(buffer, c % 2);
+ 				break;
+diff --git fontcache.c fontcache.c
+index 0b38a38..3468df9 100644
+--- fontcache.c
++++ fontcache.c
+@@ -394,6 +394,9 @@ static void SetGlyphPtr(FontSize size, WChar key, const GlyphEntry *glyph)
+ 	width  = max(1, slot->bitmap.width + (size == FS_NORMAL));
+ 	height = max(1, slot->bitmap.rows  + (size == FS_NORMAL));
+ 
++	/* Limit glyph size to prevent overflows later on. */
++	if (width > 256 || height > 256) error("Font glyph is too large");
++
+ 	/* FreeType has rendered the glyph, now we allocate a sprite and copy the image into it */
+ 	sprite = calloc(width * height + 8, 1);
+ 	sprite->info   = 1;
+diff --git heightmap.c heightmap.c
+index adc2a53..145f871 100644
+--- heightmap.c
++++ heightmap.c
+@@ -134,6 +134,14 @@ static bool ReadHeightmapPNG(char *filename, uint *x, uint *y, byte **map)
+ 		return false;
+ 	}
+ 
++	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
++	if ((uint64)info_ptr->width * info_ptr->height >= (size_t)-1) {
++		ShowErrorMessage(STR_ERROR_HEIGHTMAP_TOO_LARGE, STR_PNGMAP_ERROR, 0, 0);
++		fclose(fp);
++		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
++		return false;
++	}
++
+ 	if (map != NULL) {
+ 		*map = malloc(info_ptr->width * info_ptr->height * sizeof(byte));
+ 
+@@ -243,6 +251,14 @@ static bool ReadHeightmapBMP(char *filename, uint *x, uint *y, byte **map)
+ 		return false;
+ 	}
+ 
++	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
++	if ((uint64)info.width * info.height >= (size_t)-1 / (info.bpp == 24 ? 3 : 1)) {
++		ShowErrorMessage(STR_ERROR_HEIGHTMAP_TOO_LARGE, STR_BMPMAP_ERROR, 0, 0);
++		fclose(f);
++		BmpDestroyData(&data);
++		return false;
++	}
++
+ 	if (map != NULL) {
+ 		if (!BmpReadBitmap(&buffer, &info, &data)) {
+ 			ShowErrorMessage(STR_BMPMAP_ERR_IMAGE_TYPE, STR_BMPMAP_ERROR, 0, 0);
+diff --git lang/english.txt lang/english.txt
+index 47a9425..fb7e07e 100644
+--- lang/english.txt
++++ lang/english.txt
+@@ -1499,6 +1499,8 @@ STR_PNGMAP_ERR_MISC                                             :{WHITE}...somet
+ STR_BMPMAP_ERROR                                                :{WHITE}Cannot load landscape from BMP...
+ STR_BMPMAP_ERR_IMAGE_TYPE                                       :{WHITE}...could not convert image type.
+ 
++STR_ERROR_HEIGHTMAP_TOO_LARGE                                   :{WHITE}... image is too large
++
+ ##id 0x0800
+ STR_0800_COST                                                   :{TINYFONT}{RED}Cost: {CURRENCY}
+ STR_0801_COST                                                   :{RED}Cost: {CURRENCY}
+diff --git sound.c sound.c
+index e4666a1..b19efee 100644
+--- sound.c
++++ sound.c
+@@ -107,7 +107,8 @@ static bool SetBankSource(MixerChannel *mc, uint bank)
+ 	if (bank >= GetNumSounds()) return false;
+ 	fe = GetSound(bank);
+ 
+-	if (fe->file_size == 0) return false;
++	/* Check for valid sound size. */
++	if (fe->file_size == 0 || fe->file_size > ((size_t)-1) - 2) return false;
+ 
+ 	mem = malloc(fe->file_size);
+ 	if (mem == NULL) return false;

--- a/_security/CVE-2011-3343/0.6.0 - 0.6.3.patch
+++ b/_security/CVE-2011-3343/0.6.0 - 0.6.3.patch
@@ -1,0 +1,173 @@
+---
+layout: security_patch
+cve: CVE-2011-3343
+first_version: 0.6.0
+last_version: 0.6.3
+---
+
+diff --git src/bmp.cpp src/bmp.cpp
+index c5677fb..4ee1964 100644
+--- src/bmp.cpp
++++ src/bmp.cpp
+@@ -135,6 +135,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			switch (c) {
+ 			case 0: // end of line
+ 				x = 0;
++				if (y == 0) return false;
+ 				pixel = &data->bitmap[--y * info->width];
+ 				break;
+ 			case 1: // end of bitmap
+@@ -145,7 +146,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			case 2: // delta
+ 				x += ReadByte(buffer);
+ 				i = ReadByte(buffer);
+-				if (x >= info->width || (y == 0 && i > 0)) return false;
++				if (x >= info->width || i > y) return false;
+ 				y -= i;
+ 				pixel = &data->bitmap[y * info->width + x];
+ 				break;
+@@ -218,6 +219,7 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			switch (c) {
+ 			case 0: // end of line
+ 				x = 0;
++				if (y == 0) return false;
+ 				pixel = &data->bitmap[--y * info->width];
+ 				break;
+ 			case 1: // end of bitmap
+@@ -228,13 +230,16 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			case 2: // delta
+ 				x += ReadByte(buffer);
+ 				i = ReadByte(buffer);
+-				if (x >= info->width || (y == 0 && i > 0)) return false;
++				if (x >= info->width || i > y) return false;
+ 				y -= i;
+ 				pixel = &data->bitmap[y * info->width + x];
+ 				break;
+ 			default: // uncompressed
+-				if ((x += c) > info->width) return false;
+-				for (i = 0; i < c; i++) *pixel++ = ReadByte(buffer);
++				for (i = 0; i < c; i++) {
++					if (EndOfBuffer(buffer) || x >= info->width) return false;
++					*pixel++ = ReadByte(buffer);
++					x++;
++				}
+ 				/* Padding for 16 bit align */
+ 				SkipBytes(buffer, c % 2);
+ 				break;
+diff --git src/fontcache.cpp src/fontcache.cpp
+index 4774279..74d0024 100644
+--- src/fontcache.cpp
++++ src/fontcache.cpp
+@@ -422,6 +422,9 @@ static bool GetFontAAState(FontSize size)
+ 	width  = max(1, slot->bitmap.width + (size == FS_NORMAL));
+ 	height = max(1, slot->bitmap.rows  + (size == FS_NORMAL));
+ 
++	/* Limit glyph size to prevent overflows later on. */
++	if (width > 256 || height > 256) error("Font glyph is too large");
++
+ 	/* FreeType has rendered the glyph, now we allocate a sprite and copy the image into it */
+ 	sprite.data = CallocT<SpriteLoader::CommonPixel>(width * height);
+ 	sprite.width = width;
+diff --git src/heightmap.cpp src/heightmap.cpp
+index c04ebd8..e2645a5 100644
+--- src/heightmap.cpp
++++ src/heightmap.cpp
+@@ -139,6 +139,14 @@ static bool ReadHeightmapPNG(char *filename, uint *x, uint *y, byte **map)
+ 		return false;
+ 	}
+ 
++	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
++	if ((uint64)info_ptr->width * info_ptr->height >= (size_t)-1) {
++		ShowErrorMessage(STR_ERROR_HEIGHTMAP_TOO_LARGE, STR_PNGMAP_ERROR, 0, 0);
++		fclose(fp);
++		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
++		return false;
++	}
++
+ 	if (map != NULL) {
+ 		*map = MallocT<byte>(info_ptr->width * info_ptr->height);
+ 
+@@ -248,6 +256,14 @@ static bool ReadHeightmapBMP(char *filename, uint *x, uint *y, byte **map)
+ 		return false;
+ 	}
+ 
++	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
++	if ((uint64)info.width * info.height >= (size_t)-1 / (info.bpp == 24 ? 3 : 1)) {
++		ShowErrorMessage(STR_ERROR_HEIGHTMAP_TOO_LARGE, STR_BMPMAP_ERROR, 0, 0);
++		fclose(f);
++		BmpDestroyData(&data);
++		return false;
++	}
++
+ 	if (map != NULL) {
+ 		if (!BmpReadBitmap(&buffer, &info, &data)) {
+ 			ShowErrorMessage(STR_BMPMAP_ERR_IMAGE_TYPE, STR_BMPMAP_ERROR, 0, 0);
+diff --git src/lang/english.txt src/lang/english.txt
+index 19b4e35..35402ae 100644
+--- src/lang/english.txt
++++ src/lang/english.txt
+@@ -1585,6 +1585,8 @@ STR_PNGMAP_ERR_MISC                                             :{WHITE}...somet
+ STR_BMPMAP_ERROR                                                :{WHITE}Cannot load landscape from BMP...
+ STR_BMPMAP_ERR_IMAGE_TYPE                                       :{WHITE}...could not convert image type.
+ 
++STR_ERROR_HEIGHTMAP_TOO_LARGE                                   :{WHITE}... image is too large
++
+ ##id 0x0800
+ STR_0800_COST                                                   :{TINYFONT}{RED}Cost: {CURRENCY}
+ STR_0801_COST                                                   :{RED}Cost: {CURRENCY}
+diff --git src/sound.cpp src/sound.cpp
+index 9fed4a6..fef60b5 100644
+--- src/sound.cpp
++++ src/sound.cpp
+@@ -117,7 +117,8 @@ static bool SetBankSource(MixerChannel *mc, const FileEntry *fe)
+ {
+ 	assert(fe != NULL);
+ 
+-	if (fe->file_size == 0) return false;
++	/* Check for valid sound size. */
++	if (fe->file_size == 0 || fe->file_size > ((size_t)-1) - 2) return false;
+ 
+ 	int8 *mem = MallocT<int8>(fe->file_size);
+ 	if (mem == NULL) return false;
+diff --git src/sound/win32_s.cpp src/sound/win32_s.cpp
+index 386c6f4..2c184c6 100644
+--- src/sound/win32_s.cpp
++++ src/sound/win32_s.cpp
+@@ -60,6 +60,7 @@ static void CALLBACK waveOutProc(HWAVEOUT hwo, UINT uMsg, DWORD_PTR dwInstance,
+ 	wfex.nAvgBytesPerSec = wfex.nSamplesPerSec * wfex.nBlockAlign;
+ 
+ 	_bufsize = GetDriverParamInt(parm, "bufsize", (GB(GetVersion(), 0, 8) > 5) ? 2048 : 1024);
++	_bufsize = min(_bufsize, 65535);
+ 
+ 	if (waveOutOpen(&_waveout, WAVE_MAPPER, &wfex, (DWORD_PTR)&waveOutProc, 0, CALLBACK_FUNCTION) != MMSYSERR_NOERROR)
+ 		return "waveOutOpen failed";
+diff --git src/spriteloader/png.cpp src/spriteloader/png.cpp
+index 363dce4..26440bf 100644
+--- src/spriteloader/png.cpp
++++ src/spriteloader/png.cpp
+@@ -102,7 +102,17 @@ static bool LoadPNG(SpriteLoader::Sprite *sprite, const char *filename, uint32 i
+ 
+ 		sprite->height = info_ptr->height;
+ 		sprite->width  = info_ptr->width;
++		/* Check if sprite dimensions aren't larger than what is allowed in GRF-files. */
++		if (info_ptr->height > 255 || info_ptr->width > 65535) {
++			png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
++			return false;
++		}
+ 		sprite->data = CallocT<SpriteLoader::CommonPixel>(sprite->width * sprite->height);
++	} else if (sprite->height != info_ptr->height || sprite->width != info_ptr->width) {
++		/* Make sure the mask image isn't larger than the sprite image. */
++		DEBUG(misc, 0, "Ignoring mask for SpriteID %d as it isn't the same dimension as the masked sprite", id);
++		png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
++		return true;
+ 	}
+ 
+ 	bit_depth  = png_get_bit_depth(png_ptr, info_ptr);
+@@ -110,6 +120,7 @@ static bool LoadPNG(SpriteLoader::Sprite *sprite, const char *filename, uint32 i
+ 
+ 	if (mask && (bit_depth != 8 || color_type != PNG_COLOR_TYPE_PALETTE)) {
+ 		DEBUG(misc, 0, "Ignoring mask for SpriteID %d as it isn't a 8 bit palette image", id);
++		png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+ 		return true;
+ 	}
+ 

--- a/_security/CVE-2011-3343/0.7.0 - 0.7.5.patch
+++ b/_security/CVE-2011-3343/0.7.0 - 0.7.5.patch
@@ -1,0 +1,208 @@
+---
+layout: security_patch
+cve: CVE-2011-3343
+first_version: 0.7.0
+last_version: 0.7.5
+---
+
+diff --git src/bmp.cpp src/bmp.cpp
+index ae277d7..a839a5c 100644
+--- src/bmp.cpp
++++ src/bmp.cpp
+@@ -135,6 +135,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			switch (c) {
+ 			case 0: // end of line
+ 				x = 0;
++				if (y == 0) return false;
+ 				pixel = &data->bitmap[--y * info->width];
+ 				break;
+ 			case 1: // end of bitmap
+@@ -145,7 +146,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			case 2: // delta
+ 				x += ReadByte(buffer);
+ 				i = ReadByte(buffer);
+-				if (x >= info->width || (y == 0 && i > 0)) return false;
++				if (x >= info->width || i > y) return false;
+ 				y -= i;
+ 				pixel = &data->bitmap[y * info->width + x];
+ 				break;
+@@ -218,6 +219,7 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			switch (c) {
+ 			case 0: // end of line
+ 				x = 0;
++				if (y == 0) return false;
+ 				pixel = &data->bitmap[--y * info->width];
+ 				break;
+ 			case 1: // end of bitmap
+@@ -228,13 +230,16 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			case 2: // delta
+ 				x += ReadByte(buffer);
+ 				i = ReadByte(buffer);
+-				if (x >= info->width || (y == 0 && i > 0)) return false;
++				if (x >= info->width || i > y) return false;
+ 				y -= i;
+ 				pixel = &data->bitmap[y * info->width + x];
+ 				break;
+ 			default: // uncompressed
+-				if ((x += c) > info->width) return false;
+-				for (i = 0; i < c; i++) *pixel++ = ReadByte(buffer);
++				for (i = 0; i < c; i++) {
++					if (EndOfBuffer(buffer) || x >= info->width) return false;
++					*pixel++ = ReadByte(buffer);
++					x++;
++				}
+ 				/* Padding for 16 bit align */
+ 				SkipBytes(buffer, c % 2);
+ 				break;
+diff --git src/fontcache.cpp src/fontcache.cpp
+index 1c1095b..bd3c75e 100644
+--- src/fontcache.cpp
++++ src/fontcache.cpp
+@@ -721,6 +721,9 @@ static bool GetFontAAState(FontSize size)
+ 	width  = max(1, slot->bitmap.width + (size == FS_NORMAL));
+ 	height = max(1, slot->bitmap.rows  + (size == FS_NORMAL));
+ 
++	/* Limit glyph size to prevent overflows later on. */
++	if (width > 256 || height > 256) usererror("Font glyph is too large");
++
+ 	/* FreeType has rendered the glyph, now we allocate a sprite and copy the image into it */
+ 	sprite.AllocateData(width * height);
+ 	sprite.width = width;
+diff --git src/heightmap.cpp src/heightmap.cpp
+index 04207cd..790847e 100644
+--- src/heightmap.cpp
++++ src/heightmap.cpp
+@@ -136,6 +136,14 @@ static bool ReadHeightmapPNG(char *filename, uint *x, uint *y, byte **map)
+ 		return false;
+ 	}
+ 
++	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
++	if ((uint64)info_ptr->width * info_ptr->height >= (size_t)-1) {
++		ShowErrorMessage(STR_ERROR_HEIGHTMAP_TOO_LARGE, STR_PNGMAP_ERROR, 0, 0);
++		fclose(fp);
++		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
++		return false;
++	}
++
+ 	if (map != NULL) {
+ 		*map = MallocT<byte>(info_ptr->width * info_ptr->height);
+ 		ReadHeightmapPNGImageData(*map, png_ptr, info_ptr);
+@@ -237,6 +245,14 @@ static bool ReadHeightmapBMP(char *filename, uint *x, uint *y, byte **map)
+ 		return false;
+ 	}
+ 
++	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
++	if ((uint64)info.width * info.height >= (size_t)-1 / (info.bpp == 24 ? 3 : 1)) {
++		ShowErrorMessage(STR_ERROR_HEIGHTMAP_TOO_LARGE, STR_BMPMAP_ERROR, 0, 0);
++		fclose(f);
++		BmpDestroyData(&data);
++		return false;
++	}
++
+ 	if (map != NULL) {
+ 		if (!BmpReadBitmap(&buffer, &info, &data)) {
+ 			ShowErrorMessage(STR_BMPMAP_ERR_IMAGE_TYPE, STR_BMPMAP_ERROR, 0, 0);
+diff --git src/lang/english.txt src/lang/english.txt
+index f0fd2d8..22525fd 100644
+--- src/lang/english.txt
++++ src/lang/english.txt
+@@ -1529,6 +1529,8 @@ STR_PNGMAP_ERR_MISC                                             :{WHITE}...somet
+ STR_BMPMAP_ERROR                                                :{WHITE}Can't load landscape from BMP...
+ STR_BMPMAP_ERR_IMAGE_TYPE                                       :{WHITE}...could not convert image type.
+ 
++STR_ERROR_HEIGHTMAP_TOO_LARGE                                   :{WHITE}... image is too large
++
+ ##id 0x0800
+ STR_0800_COST                                                   :{TINYFONT}{RED}Cost: {CURRENCY}
+ STR_0801_COST                                                   :{RED}Cost: {CURRENCY}
+diff --git src/openttd.cpp src/openttd.cpp
+index 70525cd..9ccf7fe 100644
+--- src/openttd.cpp
++++ src/openttd.cpp
+@@ -540,11 +540,12 @@ int ttd_main(int argc, char *argv[])
+ 
+ 	/*
+ 	 * The width and height must be at least 1 pixel and width times
+-	 * height must still fit within a 32 bits integer, this way all
+-	 * internal drawing routines work correctly.
++	 * height times bytes per pixel must still fit within a 32 bits
++	 * integer, even for 32 bpp video modes. This way all internal
++	 * drawing routines work correctly.
+ 	 */
+-	_cur_resolution.width  = ClampU(_cur_resolution.width,  1, UINT16_MAX);
+-	_cur_resolution.height = ClampU(_cur_resolution.height, 1, UINT16_MAX);
++	_cur_resolution.width  = ClampU(_cur_resolution.width,  1, UINT16_MAX / 2);
++	_cur_resolution.height = ClampU(_cur_resolution.height, 1, UINT16_MAX / 2);
+ 
+ #if defined(ENABLE_NETWORK)
+ 	if (dedicated_host) snprintf(_settings_client.network.server_bind_ip, sizeof(_settings_client.network.server_bind_ip), "%s", dedicated_host);
+diff --git src/script/squirrel_helper.hpp src/script/squirrel_helper.hpp
+index 2310b70..59a47b1 100644
+--- src/script/squirrel_helper.hpp
++++ src/script/squirrel_helper.hpp
+@@ -111,6 +111,9 @@
+ 
+ 	template <> inline Array      *GetParam(ForceType<Array *>,      HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr)
+ 	{
++		/* Sanity check of the size. */
++		if (sq_getsize(vm, index) > UINT16_MAX) throw sq_throwerror(vm, _SC("an array used as parameter to a function is too large"));
++
+ 		SQObject obj;
+ 		sq_getstackobj(vm, index, &obj);
+ 		sq_pushobject(vm, obj);
+diff --git src/sound.cpp src/sound.cpp
+index c487401..e6ed123 100644
+--- src/sound.cpp
++++ src/sound.cpp
+@@ -105,7 +105,8 @@ static bool SetBankSource(MixerChannel *mc, const FileEntry *fe)
+ {
+ 	assert(fe != NULL);
+ 
+-	if (fe->file_size == 0) return false;
++	/* Check for valid sound size. */
++	if (fe->file_size == 0 || fe->file_size > ((size_t)-1) - 2) return false;
+ 
+ 	int8 *mem = MallocT<int8>(fe->file_size);
+ 
+diff --git src/sound/win32_s.cpp src/sound/win32_s.cpp
+index 776158a..24d9c31 100644
+--- src/sound/win32_s.cpp
++++ src/sound/win32_s.cpp
+@@ -61,6 +61,7 @@ static void CALLBACK waveOutProc(HWAVEOUT hwo, UINT uMsg, DWORD_PTR dwInstance,
+ 	wfex.nAvgBytesPerSec = wfex.nSamplesPerSec * wfex.nBlockAlign;
+ 
+ 	_bufsize = GetDriverParamInt(parm, "bufsize", (GB(GetVersion(), 0, 8) > 5) ? 2048 : 1024);
++	_bufsize = min(_bufsize, UINT16_MAX);
+ 
+ 	if (waveOutOpen(&_waveout, WAVE_MAPPER, &wfex, (DWORD_PTR)&waveOutProc, 0, CALLBACK_FUNCTION) != MMSYSERR_NOERROR)
+ 		return "waveOutOpen failed";
+diff --git src/spriteloader/png.cpp src/spriteloader/png.cpp
+index f99237d..fb8072f 100644
+--- src/spriteloader/png.cpp
++++ src/spriteloader/png.cpp
+@@ -101,7 +101,17 @@ static bool LoadPNG(SpriteLoader::Sprite *sprite, const char *filename, uint32 i
+ 
+ 		sprite->height = info_ptr->height;
+ 		sprite->width  = info_ptr->width;
++		/* Check if sprite dimensions aren't larger than what is allowed in GRF-files. */
++		if (info_ptr->height > 255 || info_ptr->width > UINT16_MAX) {
++			png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
++			return false;
++		}
+ 		sprite->AllocateData(sprite->width * sprite->height);
++	} else if (sprite->height != info_ptr->height || sprite->width != info_ptr->width) {
++		/* Make sure the mask image isn't larger than the sprite image. */
++		DEBUG(misc, 0, "Ignoring mask for SpriteID %d as it isn't the same dimension as the masked sprite", id);
++		png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
++		return true;
+ 	}
+ 
+ 	bit_depth  = png_get_bit_depth(png_ptr, info_ptr);
+@@ -109,6 +119,7 @@ static bool LoadPNG(SpriteLoader::Sprite *sprite, const char *filename, uint32 i
+ 
+ 	if (mask && (bit_depth != 8 || colour_type != PNG_COLOR_TYPE_PALETTE)) {
+ 		DEBUG(misc, 0, "Ignoring mask for SpriteID %d as it isn't a 8 bit palette image", id);
++		png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+ 		return true;
+ 	}
+ 

--- a/_security/CVE-2011-3343/1.0.0 - 1.0.5.patch
+++ b/_security/CVE-2011-3343/1.0.0 - 1.0.5.patch
@@ -1,0 +1,229 @@
+---
+layout: security_patch
+cve: CVE-2011-3343
+first_version: 1.0.0
+last_version: 1.0.5
+---
+
+diff --git src/bmp.cpp src/bmp.cpp
+index 64b3f14..7f571ef 100644
+--- src/bmp.cpp
++++ src/bmp.cpp
+@@ -142,6 +142,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			switch (c) {
+ 			case 0: // end of line
+ 				x = 0;
++				if (y == 0) return false;
+ 				pixel = &data->bitmap[--y * info->width];
+ 				break;
+ 			case 1: // end of bitmap
+@@ -152,7 +153,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			case 2: // delta
+ 				x += ReadByte(buffer);
+ 				i = ReadByte(buffer);
+-				if (x >= info->width || (y == 0 && i > 0)) return false;
++				if (x >= info->width || i > y) return false;
+ 				y -= i;
+ 				pixel = &data->bitmap[y * info->width + x];
+ 				break;
+@@ -225,6 +226,7 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			switch (c) {
+ 			case 0: // end of line
+ 				x = 0;
++				if (y == 0) return false;
+ 				pixel = &data->bitmap[--y * info->width];
+ 				break;
+ 			case 1: // end of bitmap
+@@ -235,13 +237,16 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			case 2: // delta
+ 				x += ReadByte(buffer);
+ 				i = ReadByte(buffer);
+-				if (x >= info->width || (y == 0 && i > 0)) return false;
++				if (x >= info->width || i > y) return false;
+ 				y -= i;
+ 				pixel = &data->bitmap[y * info->width + x];
+ 				break;
+ 			default: // uncompressed
+-				if ((x += c) > info->width) return false;
+-				for (i = 0; i < c; i++) *pixel++ = ReadByte(buffer);
++				for (i = 0; i < c; i++) {
++					if (EndOfBuffer(buffer) || x >= info->width) return false;
++					*pixel++ = ReadByte(buffer);
++					x++;
++				}
+ 				/* Padding for 16 bit align */
+ 				SkipBytes(buffer, c % 2);
+ 				break;
+diff --git src/fontcache.cpp src/fontcache.cpp
+index 133f3e3..52af37f 100644
+--- src/fontcache.cpp
++++ src/fontcache.cpp
+@@ -996,6 +996,9 @@ static bool GetFontAAState(FontSize size)
+ 	width  = max(1, slot->bitmap.width + (size == FS_NORMAL));
+ 	height = max(1, slot->bitmap.rows  + (size == FS_NORMAL));
+ 
++	/* Limit glyph size to prevent overflows later on. */
++	if (width > 256 || height > 256) usererror("Font glyph is too large");
++
+ 	/* FreeType has rendered the glyph, now we allocate a sprite and copy the image into it */
+ 	sprite.AllocateData(width * height);
+ 	sprite.width = width;
+diff --git src/heightmap.cpp src/heightmap.cpp
+index 68a1ecf..4ac2f60 100644
+--- src/heightmap.cpp
++++ src/heightmap.cpp
+@@ -142,13 +142,24 @@ static bool ReadHeightmapPNG(char *filename, uint *x, uint *y, byte **map)
+ 		return false;
+ 	}
+ 
++	uint width = png_get_image_width(png_ptr, info_ptr);
++	uint height = png_get_image_height(png_ptr, info_ptr);
++
++	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
++	if ((uint64)width * height >= (size_t)-1) {
++		ShowErrorMessage(STR_ERROR_PNGMAP, STR_ERROR_HEIGHTMAP_TOO_LARGE, 0, 0);
++		fclose(fp);
++		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
++		return false;
++	}
++
+ 	if (map != NULL) {
+-		*map = MallocT<byte>(png_get_image_width(png_ptr, info_ptr) * png_get_image_height(png_ptr, info_ptr));
++		*map = MallocT<byte>(width * height);
+ 		ReadHeightmapPNGImageData(*map, png_ptr, info_ptr);
+ 	}
+ 
+-	*x = png_get_image_width(png_ptr, info_ptr);
+-	*y = png_get_image_height(png_ptr, info_ptr);
++	*x = width;
++	*y = height;
+ 
+ 	fclose(fp);
+ 	png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+@@ -243,6 +254,14 @@ static bool ReadHeightmapBMP(char *filename, uint *x, uint *y, byte **map)
+ 		return false;
+ 	}
+ 
++	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
++	if ((uint64)info.width * info.height >= (size_t)-1 / (info.bpp == 24 ? 3 : 1)) {
++		ShowErrorMessage(STR_ERROR_BMPMAP, STR_ERROR_HEIGHTMAP_TOO_LARGE, 0, 0);
++		fclose(f);
++		BmpDestroyData(&data);
++		return false;
++	}
++
+ 	if (map != NULL) {
+ 		if (!BmpReadBitmap(&buffer, &info, &data)) {
+ 			ShowErrorMessage(STR_ERROR_BMPMAP, STR_ERROR_BMPMAP_IMAGE_TYPE, 0, 0);
+diff --git src/lang/english.txt src/lang/english.txt
+index a9c4147..b025204 100644
+--- src/lang/english.txt
++++ src/lang/english.txt
+@@ -3333,6 +3333,8 @@ STR_ERROR_PNGMAP_MISC                                           :{WHITE}... some
+ STR_ERROR_BMPMAP                                                :{WHITE}Can't load landscape from BMP...
+ STR_ERROR_BMPMAP_IMAGE_TYPE                                     :{WHITE}... could not convert image type.
+ 
++STR_ERROR_HEIGHTMAP_TOO_LARGE                                   :{WHITE}... image is too large
++
+ STR_WARNING_HEIGHTMAP_SCALE_CAPTION                             :{WHITE}Scale warning
+ STR_WARNING_HEIGHTMAP_SCALE_MESSAGE                             :{YELLOW}Resizing source map too much is not recommended. Continue with the generation?
+ 
+diff --git src/openttd.cpp src/openttd.cpp
+index b636402..335bcc9 100644
+--- src/openttd.cpp
++++ src/openttd.cpp
+@@ -584,11 +584,12 @@ int ttd_main(int argc, char *argv[])
+ 
+ 	/*
+ 	 * The width and height must be at least 1 pixel and width times
+-	 * height must still fit within a 32 bits integer, this way all
+-	 * internal drawing routines work correctly.
++	 * height times bytes per pixel must still fit within a 32 bits
++	 * integer, even for 32 bpp video modes. This way all internal
++	 * drawing routines work correctly.
+ 	 */
+-	_cur_resolution.width  = ClampU(_cur_resolution.width,  1, UINT16_MAX);
+-	_cur_resolution.height = ClampU(_cur_resolution.height, 1, UINT16_MAX);
++	_cur_resolution.width  = ClampU(_cur_resolution.width,  1, UINT16_MAX / 2);
++	_cur_resolution.height = ClampU(_cur_resolution.height, 1, UINT16_MAX / 2);
+ 
+ #if defined(ENABLE_NETWORK)
+ 	if (dedicated_host) {
+diff --git src/script/squirrel_helper.hpp src/script/squirrel_helper.hpp
+index 67f8a21..eded9a7 100644
+--- src/script/squirrel_helper.hpp
++++ src/script/squirrel_helper.hpp
+@@ -118,6 +118,9 @@
+ 
+ 	template <> inline Array      *GetParam(ForceType<Array *>,      HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr)
+ 	{
++		/* Sanity check of the size. */
++		if (sq_getsize(vm, index) > UINT16_MAX) throw sq_throwerror(vm, _SC("an array used as parameter to a function is too large"));
++
+ 		SQObject obj;
+ 		sq_getstackobj(vm, index, &obj);
+ 		sq_pushobject(vm, obj);
+diff --git src/sound.cpp src/sound.cpp
+index e337b5e..5a87006 100644
+--- src/sound.cpp
++++ src/sound.cpp
+@@ -114,7 +114,8 @@ static bool SetBankSource(MixerChannel *mc, const SoundEntry *sound)
+ {
+ 	assert(sound != NULL);
+ 
+-	if (sound->file_size == 0) return false;
++	/* Check for valid sound size. */
++	if (sound->file_size == 0 || sound->file_size > ((size_t)-1) - 2) return false;
+ 
+ 	int8 *mem = MallocT<int8>(sound->file_size + 2);
+ 	/* Add two extra bytes so rate conversion can read these
+diff --git src/sound/win32_s.cpp src/sound/win32_s.cpp
+index c0e5da5..ef3f98f 100644
+--- src/sound/win32_s.cpp
++++ src/sound/win32_s.cpp
+@@ -63,7 +63,9 @@ static DWORD WINAPI SoundThread(LPVOID arg)
+ 	wfex.nBlockAlign = (wfex.nChannels * wfex.wBitsPerSample) / 8;
+ 	wfex.nAvgBytesPerSec = wfex.nSamplesPerSec * wfex.nBlockAlign;
+ 
++	/* Limit buffer size to prevent overflows. */
+ 	_bufsize = GetDriverParamInt(parm, "bufsize", (GB(GetVersion(), 0, 8) > 5) ? 8192 : 4096);
++	_bufsize = min(_bufsize, UINT16_MAX);
+ 
+ 	try {
+ 		if (NULL == (_event = CreateEvent(NULL, FALSE, FALSE, NULL))) throw "Failed to create event";
+diff --git src/spriteloader/png.cpp src/spriteloader/png.cpp
+index e72f440..4378c7f 100644
+--- src/spriteloader/png.cpp
++++ src/spriteloader/png.cpp
+@@ -106,9 +106,21 @@ static bool LoadPNG(SpriteLoader::Sprite *sprite, const char *filename, uint32 i
+ 			if (strcmp("y_offs", text_ptr[i].key) == 0) sprite->y_offs = strtol(text_ptr[i].text, NULL, 0);
+ 		}
+ 
+-		sprite->height = png_get_image_height(png_ptr, info_ptr);
+-		sprite->width  = png_get_image_width(png_ptr, info_ptr);
++		uint height = png_get_image_height(png_ptr, info_ptr);
++		uint width = png_get_image_width(png_ptr, info_ptr);
++		/* Check if sprite dimensions aren't larger than what is allowed in GRF-files. */
++		if (height > UINT8_MAX || width > UINT16_MAX) {
++			png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
++			return false;
++		}
++		sprite->height = height;
++		sprite->width  = width;
+ 		sprite->AllocateData(sprite->width * sprite->height);
++	} else if (sprite->height != png_get_image_height(png_ptr, info_ptr) || sprite->width != png_get_image_width(png_ptr, info_ptr)) {
++		/* Make sure the mask image isn't larger than the sprite image. */
++		DEBUG(misc, 0, "Ignoring mask for SpriteID %d as it isn't the same dimension as the masked sprite", id);
++		png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
++		return true;
+ 	}
+ 
+ 	bit_depth  = png_get_bit_depth(png_ptr, info_ptr);
+@@ -116,6 +128,7 @@ static bool LoadPNG(SpriteLoader::Sprite *sprite, const char *filename, uint32 i
+ 
+ 	if (mask && (bit_depth != 8 || colour_type != PNG_COLOR_TYPE_PALETTE)) {
+ 		DEBUG(misc, 0, "Ignoring mask for SpriteID %d as it isn't a 8 bit palette image", id);
++		png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+ 		return true;
+ 	}
+ 

--- a/_security/CVE-2011-3343/1.1.0 - 1.1.2.patch
+++ b/_security/CVE-2011-3343/1.1.0 - 1.1.2.patch
@@ -1,0 +1,229 @@
+---
+layout: security_patch
+cve: CVE-2011-3343
+first_version: 1.1.0
+last_version: 1.1.2
+---
+
+diff --git src/bmp.cpp src/bmp.cpp
+index 2c85c76..d39f619 100644
+--- src/bmp.cpp
++++ src/bmp.cpp
+@@ -143,6 +143,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			switch (c) {
+ 			case 0: // end of line
+ 				x = 0;
++				if (y == 0) return false;
+ 				pixel = &data->bitmap[--y * info->width];
+ 				break;
+ 			case 1: // end of bitmap
+@@ -153,7 +154,7 @@ static inline bool BmpRead4Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			case 2: // delta
+ 				x += ReadByte(buffer);
+ 				i = ReadByte(buffer);
+-				if (x >= info->width || (y == 0 && i > 0)) return false;
++				if (x >= info->width || i > y) return false;
+ 				y -= i;
+ 				pixel = &data->bitmap[y * info->width + x];
+ 				break;
+@@ -226,6 +227,7 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			switch (c) {
+ 			case 0: // end of line
+ 				x = 0;
++				if (y == 0) return false;
+ 				pixel = &data->bitmap[--y * info->width];
+ 				break;
+ 			case 1: // end of bitmap
+@@ -236,13 +238,16 @@ static inline bool BmpRead8Rle(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
+ 			case 2: // delta
+ 				x += ReadByte(buffer);
+ 				i = ReadByte(buffer);
+-				if (x >= info->width || (y == 0 && i > 0)) return false;
++				if (x >= info->width || i > y) return false;
+ 				y -= i;
+ 				pixel = &data->bitmap[y * info->width + x];
+ 				break;
+ 			default: // uncompressed
+-				if ((x += c) > info->width) return false;
+-				for (i = 0; i < c; i++) *pixel++ = ReadByte(buffer);
++				for (i = 0; i < c; i++) {
++					if (EndOfBuffer(buffer) || x >= info->width) return false;
++					*pixel++ = ReadByte(buffer);
++					x++;
++				}
+ 				/* Padding for 16 bit align */
+ 				SkipBytes(buffer, c % 2);
+ 				break;
+diff --git src/fontcache.cpp src/fontcache.cpp
+index b279c34..616c54a 100644
+--- src/fontcache.cpp
++++ src/fontcache.cpp
+@@ -1034,6 +1034,9 @@ static bool GetFontAAState(FontSize size)
+ 	width  = max(1, slot->bitmap.width + (size == FS_NORMAL));
+ 	height = max(1, slot->bitmap.rows  + (size == FS_NORMAL));
+ 
++	/* Limit glyph size to prevent overflows later on. */
++	if (width > 256 || height > 256) usererror("Font glyph is too large");
++
+ 	/* FreeType has rendered the glyph, now we allocate a sprite and copy the image into it */
+ 	sprite.AllocateData(width * height);
+ 	sprite.width = width;
+diff --git src/heightmap.cpp src/heightmap.cpp
+index 07b1e5e..b85bcd9 100644
+--- src/heightmap.cpp
++++ src/heightmap.cpp
+@@ -142,13 +142,24 @@ static bool ReadHeightmapPNG(char *filename, uint *x, uint *y, byte **map)
+ 		return false;
+ 	}
+ 
++	uint width = png_get_image_width(png_ptr, info_ptr);
++	uint height = png_get_image_height(png_ptr, info_ptr);
++
++	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
++	if ((uint64)width * height >= (size_t)-1) {
++		ShowErrorMessage(STR_ERROR_PNGMAP, STR_ERROR_HEIGHTMAP_TOO_LARGE, WL_ERROR);
++		fclose(fp);
++		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
++		return false;
++	}
++
+ 	if (map != NULL) {
+-		*map = MallocT<byte>(png_get_image_width(png_ptr, info_ptr) * png_get_image_height(png_ptr, info_ptr));
++		*map = MallocT<byte>(width * height);
+ 		ReadHeightmapPNGImageData(*map, png_ptr, info_ptr);
+ 	}
+ 
+-	*x = png_get_image_width(png_ptr, info_ptr);
+-	*y = png_get_image_height(png_ptr, info_ptr);
++	*x = width;
++	*y = height;
+ 
+ 	fclose(fp);
+ 	png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+@@ -243,6 +254,14 @@ static bool ReadHeightmapBMP(char *filename, uint *x, uint *y, byte **map)
+ 		return false;
+ 	}
+ 
++	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
++	if ((uint64)info.width * info.height >= (size_t)-1 / (info.bpp == 24 ? 3 : 1)) {
++		ShowErrorMessage(STR_ERROR_BMPMAP, STR_ERROR_HEIGHTMAP_TOO_LARGE, WL_ERROR);
++		fclose(f);
++		BmpDestroyData(&data);
++		return false;
++	}
++
+ 	if (map != NULL) {
+ 		if (!BmpReadBitmap(&buffer, &info, &data)) {
+ 			ShowErrorMessage(STR_ERROR_BMPMAP, STR_ERROR_BMPMAP_IMAGE_TYPE, WL_ERROR);
+diff --git src/lang/english.txt src/lang/english.txt
+index f8b341a..e2b778c 100644
+--- src/lang/english.txt
++++ src/lang/english.txt
+@@ -3452,6 +3452,8 @@ STR_ERROR_PNGMAP_MISC                                           :{WHITE}... some
+ STR_ERROR_BMPMAP                                                :{WHITE}Can't load landscape from BMP...
+ STR_ERROR_BMPMAP_IMAGE_TYPE                                     :{WHITE}... could not convert image type
+ 
++STR_ERROR_HEIGHTMAP_TOO_LARGE                                   :{WHITE}... image is too large
++
+ STR_WARNING_HEIGHTMAP_SCALE_CAPTION                             :{WHITE}Scale warning
+ STR_WARNING_HEIGHTMAP_SCALE_MESSAGE                             :{YELLOW}Resizing source map too much is not recommended. Continue with the generation?
+ 
+diff --git src/openttd.cpp src/openttd.cpp
+index 5cd5eba..af1f77f 100644
+--- src/openttd.cpp
++++ src/openttd.cpp
+@@ -596,11 +596,12 @@ int ttd_main(int argc, char *argv[])
+ 
+ 	/*
+ 	 * The width and height must be at least 1 pixel and width times
+-	 * height must still fit within a 32 bits integer, this way all
+-	 * internal drawing routines work correctly.
++	 * height times bytes per pixel must still fit within a 32 bits
++	 * integer, even for 32 bpp video modes. This way all internal
++	 * drawing routines work correctly.
+ 	 */
+-	_cur_resolution.width  = ClampU(_cur_resolution.width,  1, UINT16_MAX);
+-	_cur_resolution.height = ClampU(_cur_resolution.height, 1, UINT16_MAX);
++	_cur_resolution.width  = ClampU(_cur_resolution.width,  1, UINT16_MAX / 2);
++	_cur_resolution.height = ClampU(_cur_resolution.height, 1, UINT16_MAX / 2);
+ 
+ 	/* enumerate language files */
+ 	InitializeLanguagePacks();
+diff --git src/script/squirrel_helper.hpp src/script/squirrel_helper.hpp
+index a7d0bf7..babdf74 100644
+--- src/script/squirrel_helper.hpp
++++ src/script/squirrel_helper.hpp
+@@ -118,6 +118,9 @@
+ 
+ 	template <> inline Array      *GetParam(ForceType<Array *>,      HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr)
+ 	{
++		/* Sanity check of the size. */
++		if (sq_getsize(vm, index) > UINT16_MAX) throw sq_throwerror(vm, _SC("an array used as parameter to a function is too large"));
++
+ 		SQObject obj;
+ 		sq_getstackobj(vm, index, &obj);
+ 		sq_pushobject(vm, obj);
+diff --git src/sound.cpp src/sound.cpp
+index 2834078..89d2224 100644
+--- src/sound.cpp
++++ src/sound.cpp
+@@ -110,7 +110,8 @@ static bool SetBankSource(MixerChannel *mc, const SoundEntry *sound)
+ {
+ 	assert(sound != NULL);
+ 
+-	if (sound->file_size == 0) return false;
++	/* Check for valid sound size. */
++	if (sound->file_size == 0 || sound->file_size > ((size_t)-1) - 2) return false;
+ 
+ 	int8 *mem = MallocT<int8>(sound->file_size + 2);
+ 	/* Add two extra bytes so rate conversion can read these
+diff --git src/sound/win32_s.cpp src/sound/win32_s.cpp
+index c0e5da5..ef3f98f 100644
+--- src/sound/win32_s.cpp
++++ src/sound/win32_s.cpp
+@@ -63,7 +63,9 @@ static DWORD WINAPI SoundThread(LPVOID arg)
+ 	wfex.nBlockAlign = (wfex.nChannels * wfex.wBitsPerSample) / 8;
+ 	wfex.nAvgBytesPerSec = wfex.nSamplesPerSec * wfex.nBlockAlign;
+ 
++	/* Limit buffer size to prevent overflows. */
+ 	_bufsize = GetDriverParamInt(parm, "bufsize", (GB(GetVersion(), 0, 8) > 5) ? 8192 : 4096);
++	_bufsize = min(_bufsize, UINT16_MAX);
+ 
+ 	try {
+ 		if (NULL == (_event = CreateEvent(NULL, FALSE, FALSE, NULL))) throw "Failed to create event";
+diff --git src/spriteloader/png.cpp src/spriteloader/png.cpp
+index e72f440..4378c7f 100644
+--- src/spriteloader/png.cpp
++++ src/spriteloader/png.cpp
+@@ -106,9 +106,21 @@ static bool LoadPNG(SpriteLoader::Sprite *sprite, const char *filename, uint32 i
+ 			if (strcmp("y_offs", text_ptr[i].key) == 0) sprite->y_offs = strtol(text_ptr[i].text, NULL, 0);
+ 		}
+ 
+-		sprite->height = png_get_image_height(png_ptr, info_ptr);
+-		sprite->width  = png_get_image_width(png_ptr, info_ptr);
++		uint height = png_get_image_height(png_ptr, info_ptr);
++		uint width = png_get_image_width(png_ptr, info_ptr);
++		/* Check if sprite dimensions aren't larger than what is allowed in GRF-files. */
++		if (height > UINT8_MAX || width > UINT16_MAX) {
++			png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
++			return false;
++		}
++		sprite->height = height;
++		sprite->width  = width;
+ 		sprite->AllocateData(sprite->width * sprite->height);
++	} else if (sprite->height != png_get_image_height(png_ptr, info_ptr) || sprite->width != png_get_image_width(png_ptr, info_ptr)) {
++		/* Make sure the mask image isn't larger than the sprite image. */
++		DEBUG(misc, 0, "Ignoring mask for SpriteID %d as it isn't the same dimension as the masked sprite", id);
++		png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
++		return true;
+ 	}
+ 
+ 	bit_depth  = png_get_bit_depth(png_ptr, info_ptr);
+@@ -116,6 +128,7 @@ static bool LoadPNG(SpriteLoader::Sprite *sprite, const char *filename, uint32 i
+ 
+ 	if (mask && (bit_depth != 8 || colour_type != PNG_COLOR_TYPE_PALETTE)) {
+ 		DEBUG(misc, 0, "Ignoring mask for SpriteID %d as it isn't a 8 bit palette image", id);
++		png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+ 		return true;
+ 	}
+ 

--- a/_security/CVE-2012-0049.md
+++ b/_security/CVE-2012-0049.md
@@ -1,0 +1,49 @@
+---
+name: CVE-2012-0049
+description: Denial of service (server) via slow read attack
+first_vulnerable: 0.3.5
+first_fixed: 1.1.5
+related_bugs:
+- 4955
+related_commits:
+- bddfcae
+patches:
+- name: For version 1.1.0 up to including 1.1.4
+  file: 1.1.0 - 1.1.4.patch
+- name: For version 1.0.2 up to including 1.0.5
+  file: 1.0.2 - 1.0.5.patch
+- name: For version 1.0.1 up to including 1.0.1
+  file: 1.0.1 - 1.0.1.patch
+- name: For version 1.0.0 up to including 1.0.0
+  file: 1.0.0 - 1.0.0.patch
+- name: For version 0.7.0 up to including 0.7.5
+  file: 0.7.0 - 0.7.5.patch
+- name: For version 0.6.0 up to including 0.6.3
+  file: 0.6.0 - 0.6.3.patch
+---
+
+Using a slow read type attack it is possible to prevent anyone from joining 
+a server with virtually no resources. Once downloading the map no other
+downloads of the map can start, so downloading really slowly will prevent   
+others from joining. This can be further aggravated by the pause-on-join
+setting in which case the game is paused and the players cannot continue the 
+game during such an attack. This attack requires that the user is not banned 
+and passes the authorization to the server, although for many servers there 
+is no server password and thus authorization is easy.
+
+A similar attack can be done when performing the attack during the
+authorization phase itself, however you will not block anyone else from
+joining, unless you use connection multiple times until the connection limit 
+is reached, or stop the continuation of the game of the already joined
+players. This attack requires the user to be merely not banned.
+
+Note that versions before 0.6.0 are vulnerable as well. However, these
+versions are over five years old and not supported anymore. Therefore no
+patches for earlier versions are provided. Before 0.3.5 it is not possible  
+to exploit this bug via the internet as multiplayer over internet did not   
+exist yet. The provided patch is a simplification of the fix in 1.1.5
+because that version slightly changes the network protocol to tell people   
+they got kicked due to the (password) timeout.
+
+The attached patch does not change network compatibility. The fix in trunk
+does change network compatibility.

--- a/_security/CVE-2012-0049/0.6.0 - 0.6.3.patch
+++ b/_security/CVE-2012-0049/0.6.0 - 0.6.3.patch
@@ -1,0 +1,83 @@
+---
+layout: security_patch
+cve: CVE-2012-0049
+first_version: 0.6.0
+last_version: 0.6.3
+---
+
+Index: src/settings.cpp
+===================================================================
+--- src/settings.cpp	(revision 23768)
++++ src/settings.cpp	(working copy)
+@@ -1318,6 +1318,8 @@
+ 	  SDTG_VAR("sync_freq",           SLE_UINT16,C|S,0, _network_sync_freq,            100, 0,   100,   0, STR_NULL, NULL),
+ 	  SDTG_VAR("frame_freq",           SLE_UINT8,C|S,0, _network_frame_freq,             0, 0,   100,   0, STR_NULL, NULL),
+ 	  SDTG_VAR("max_join_time",       SLE_UINT16, S, 0, _network_max_join_time,        500, 0, 32000,   0, STR_NULL, NULL),
++	  SDTG_VAR("max_download_time",   SLE_UINT16, S,NO, _network_max_download_time,   1000, 0, 32000,   0, STR_NULL, NULL),
++	  SDTG_VAR("max_password_time",   SLE_UINT16, S,NO, _network_max_password_time,   2000, 0, 32000,   0, STR_NULL, NULL),
+ 	 SDTG_BOOL("pause_on_join",                   S, 0, _network_pause_on_join,        true,               STR_NULL, NULL),
+ 	  SDTG_STR("server_bind_ip",        SLE_STRB, S, 0, _network_server_bind_ip_host,  "0.0.0.0",          STR_NULL, NULL),
+ 	  SDTG_VAR("server_port",         SLE_UINT16, S, 0, _network_server_port,          NETWORK_DEFAULT_PORT, 0, 65535, 0, STR_NULL, NULL),
+Index: src/network/network_server.cpp
+===================================================================
+--- src/network/network_server.cpp	(revision 23768)
++++ src/network/network_server.cpp	(working copy)
+@@ -1584,18 +1584,43 @@
+ 			} else {
+ 				cs->lag_test = 0;
+ 			}
+-		} else if (cs->status == STATUS_PRE_ACTIVE) {
++		} else if (cs->status == STATUS_DONE_MAP ||
++					cs->status == STATUS_PRE_ACTIVE) {
++			/* The map has been sent, so this is for loading the map and syncing up. */
+ 			int lag = NetworkCalculateLag(cs);
+ 			if (lag > _network_max_join_time) {
+ 				IConsolePrintF(_icolour_err,"Client #%d is dropped because it took longer than %d ticks for him to join", cs->index, _network_max_join_time);
+ 				NetworkCloseClient(cs);
+ 			}
+-		} else if (cs->status == STATUS_INACTIVE) {
++		} else if (cs->status == STATUS_INACTIVE ||
++				cs->status == STATUS_AUTH) {
++			/* NewGRF check and authorized states should be handled almost instantly.
++			 * So give them some lee-way, likewise for the query with inactive. */
+ 			int lag = NetworkCalculateLag(cs);
+ 			if (lag > 4 * DAY_TICKS) {
+ 				IConsolePrintF(_icolour_err,"Client #%d is dropped because it took longer than %d ticks to start the joining process", cs->index, 4 * DAY_TICKS);
+ 				NetworkCloseClient(cs);
+ 			}
++		} else if (cs->status == STATUS_MAP) {
++			/* Downloading the map... this is the amount of time since starting the saving. */
++			int lag = NetworkCalculateLag(cs);
++			if (lag > _network_max_download_time) {
++				IConsolePrintF(_icolour_err,"Client #%d is dropped because it took longer than %d ticks for him to download the map", cs->index, _network_max_download_time);
++				NetworkCloseClient(cs);
++			}
++		} else if (cs->status == STATUS_AUTHORIZING) {
++			/* Waiting for the password. */
++			int lag = NetworkCalculateLag(cs);
++			if (lag > _network_max_password_time) {
++				IConsolePrintF(_icolour_err,"Client #%d is dropped because it took longer than %d ticks to enter the password", cs->index, _network_max_password_time);
++				NetworkCloseClient(cs);
++			}
++		} else if (cs->status == STATUS_MAP_WAIT) {
++			/* This is an internal state where we do not wait
++			 * on the client to move to a different state. */
++		} else {
++			/* Bad server/code. */
++			NOT_REACHED();
+ 		}
+ 
+ 		if (cs->status >= STATUS_PRE_ACTIVE) {
+Index: src/network/network_internal.h
+===================================================================
+--- src/network/network_internal.h	(revision 23768)
++++ src/network/network_internal.h	(working copy)
+@@ -140,6 +140,8 @@
+ VARDEF char _network_default_company_pass[NETWORK_PASSWORD_LENGTH];
+ 
+ VARDEF uint16 _network_max_join_time;             ///< Time a client can max take to join
++VARDEF uint16 _network_max_download_time;         ///< maximum amount of time, in game ticks, a client may take to download the map
++VARDEF uint16 _network_max_password_time;         ///< maximum amount of time, in game ticks, a client may take to enter the password
+ VARDEF bool _network_pause_on_join;               ///< Pause the game when a client tries to join (more chance of succeeding join)
+ 
+ VARDEF uint16 _redirect_console_to_client;

--- a/_security/CVE-2012-0049/0.7.0 - 0.7.5.patch
+++ b/_security/CVE-2012-0049/0.7.0 - 0.7.5.patch
@@ -1,0 +1,83 @@
+---
+layout: security_patch
+cve: CVE-2012-0049
+first_version: 0.7.0
+last_version: 0.7.5
+---
+
+Index: src/settings.cpp
+===================================================================
+--- src/settings.cpp	(revision 23660)
++++ src/settings.cpp	(working copy)
+@@ -1565,6 +1565,8 @@
+ 	  SDTC_VAR(network.sync_freq,            SLE_UINT16,C|S,NO,   100,        0,      100, 0, STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.frame_freq,            SLE_UINT8,C|S,NO,     0,        0,      100, 0, STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.max_join_time,        SLE_UINT16, S, NO,   500,        0,    32000, 0, STR_NULL,                                       NULL),
++	  SDTC_VAR(network.max_download_time,    SLE_UINT16, S, NO,  1000,        0,    32000, 0, STR_NULL,                                       NULL),
++	  SDTC_VAR(network.max_password_time,    SLE_UINT16, S, NO,  2000,        0,    32000, 0, STR_NULL,                                       NULL),
+ 	 SDTC_BOOL(network.pause_on_join,                    S, NO,  true,                        STR_NULL,                                       NULL),
+ 	  SDTC_STR(network.server_bind_ip,         SLE_STRB, S, NO, "0.0.0.0",                    STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.server_port,          SLE_UINT16, S, NO,NETWORK_DEFAULT_PORT,0,65535,0,STR_NULL,                                       NULL),
+Index: src/settings_type.h
+===================================================================
+--- src/settings_type.h	(revision 23660)
++++ src/settings_type.h	(working copy)
+@@ -111,6 +111,8 @@
+ 	uint16 sync_freq;                                     ///< how often do we check whether we are still in-sync
+ 	uint8  frame_freq;                                    ///< how often do we send commands to the clients
+ 	uint16 max_join_time;                                 ///< maximum amount of time, in game ticks, a client may take to join
++	uint16 max_download_time;                             ///< maximum amount of time, in game ticks, a client may take to download the map
++	uint16 max_password_time;                             ///< maximum amount of time, in game ticks, a client may take to enter the password
+ 	bool   pause_on_join;                                 ///< pause the game when people join
+ 	char   server_bind_ip[NETWORK_HOSTNAME_LENGTH];       ///< IP address the server binds to
+ 	uint16 server_port;                                   ///< port the server listens on
+Index: src/network/network_server.cpp
+===================================================================
+--- src/network/network_server.cpp	(revision 23660)
++++ src/network/network_server.cpp	(working copy)
+@@ -1619,18 +1619,43 @@
+ 			} else {
+ 				cs->lag_test = 0;
+ 			}
+-		} else if (cs->status == STATUS_PRE_ACTIVE) {
++		} else if (cs->status == STATUS_DONE_MAP ||
++					cs->status == STATUS_PRE_ACTIVE) {
++			/* The map has been sent, so this is for loading the map and syncing up. */
+ 			int lag = NetworkCalculateLag(cs);
+ 			if (lag > _settings_client.network.max_join_time) {
+ 				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks for him to join", cs->client_id, _settings_client.network.max_join_time);
+ 				NetworkCloseClient(cs);
+ 			}
+-		} else if (cs->status == STATUS_INACTIVE) {
++		} else if (cs->status == STATUS_INACTIVE ||
++				cs->status == STATUS_AUTH) {
++			/* NewGRF check and authorized states should be handled almost instantly.
++			 * So give them some lee-way, likewise for the query with inactive. */
+ 			int lag = NetworkCalculateLag(cs);
+ 			if (lag > 4 * DAY_TICKS) {
+ 				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks to start the joining process", cs->client_id, 4 * DAY_TICKS);
+ 				NetworkCloseClient(cs);
+ 			}
++		} else if (cs->status == STATUS_MAP) {
++			/* Downloading the map... this is the amount of time since starting the saving. */
++			int lag = NetworkCalculateLag(cs);
++			if (lag > _settings_client.network.max_download_time) {
++				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks for him to download the map", cs->client_id, _settings_client.network.max_download_time);
++				NetworkCloseClient(cs);
++			}
++		} else if (cs->status == STATUS_AUTHORIZING) {
++			/* Waiting for the password. */
++			int lag = NetworkCalculateLag(cs);
++			if (lag > _settings_client.network.max_password_time) {
++				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks to enter the password", cs->client_id, _settings_client.network.max_password_time);
++				NetworkCloseClient(cs);
++			}
++		} else if (cs->status == STATUS_MAP_WAIT) {
++			/* This is an internal state where we do not wait
++			 * on the client to move to a different state. */
++		} else {
++			/* Bad server/code. */
++			NOT_REACHED();
+ 		}
+ 
+ 		if (cs->status >= STATUS_PRE_ACTIVE) {

--- a/_security/CVE-2012-0049/1.0.0 - 1.0.0.patch
+++ b/_security/CVE-2012-0049/1.0.0 - 1.0.0.patch
@@ -1,0 +1,83 @@
+---
+layout: security_patch
+cve: CVE-2012-0049
+first_version: 1.0.0
+last_version: 1.0.0
+---
+
+Index: src/table/settings.h
+===================================================================
+--- src/table/settings.h	(revision 19530)
++++ src/table/settings.h	(working copy)
+@@ -610,6 +610,8 @@
+ 	  SDTC_VAR(network.sync_freq,            SLE_UINT16,C|S,NO,   100,        0,      100, 0, STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.frame_freq,            SLE_UINT8,C|S,NO,     0,        0,      100, 0, STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.max_join_time,        SLE_UINT16, S, NO,   500,        0,    32000, 0, STR_NULL,                                       NULL),
++	  SDTC_VAR(network.max_download_time,    SLE_UINT16, S, NO,  1000,        0,    32000, 0, STR_NULL,                                       NULL),
++	  SDTC_VAR(network.max_password_time,    SLE_UINT16, S, NO,  2000,        0,    32000, 0, STR_NULL,                                       NULL),
+ 	 SDTC_BOOL(network.pause_on_join,                    S, NO,  true,                        STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.server_port,          SLE_UINT16, S, NO,NETWORK_DEFAULT_PORT,0,65535,0,STR_NULL,                                       NULL),
+ 	 SDTC_BOOL(network.server_advertise,                 S, NO, false,                        STR_NULL,                                       NULL),
+Index: src/settings_type.h
+===================================================================
+--- src/settings_type.h	(revision 19530)
++++ src/settings_type.h	(working copy)
+@@ -125,6 +125,8 @@
+ 	uint16 sync_freq;                                     ///< how often do we check whether we are still in-sync
+ 	uint8  frame_freq;                                    ///< how often do we send commands to the clients
+ 	uint16 max_join_time;                                 ///< maximum amount of time, in game ticks, a client may take to join
++	uint16 max_download_time;                             ///< maximum amount of time, in game ticks, a client may take to download the map
++	uint16 max_password_time;                             ///< maximum amount of time, in game ticks, a client may take to enter the password
+ 	bool   pause_on_join;                                 ///< pause the game when people join
+ 	uint16 server_port;                                   ///< port the server listens on
+ 	char   server_name[NETWORK_NAME_LENGTH];              ///< name of the server
+Index: src/network/network_server.cpp
+===================================================================
+--- src/network/network_server.cpp	(revision 19530)
++++ src/network/network_server.cpp	(working copy)
+@@ -1620,18 +1620,43 @@
+ 			} else {
+ 				cs->lag_test = 0;
+ 			}
+-		} else if (cs->status == STATUS_PRE_ACTIVE) {
++		} else if (cs->status == STATUS_DONE_MAP ||
++					cs->status == STATUS_PRE_ACTIVE) {
++			/* The map has been sent, so this is for loading the map and syncing up. */
+ 			int lag = NetworkCalculateLag(cs);
+ 			if (lag > _settings_client.network.max_join_time) {
+ 				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks for him to join", cs->client_id, _settings_client.network.max_join_time);
+ 				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
+ 			}
+-		} else if (cs->status == STATUS_INACTIVE) {
++		} else if (cs->status == STATUS_INACTIVE ||
++				cs->status == STATUS_AUTH) {
++			/* NewGRF check and authorized states should be handled almost instantly.
++			 * So give them some lee-way, likewise for the query with inactive. */
+ 			int lag = NetworkCalculateLag(cs);
+ 			if (lag > 4 * DAY_TICKS) {
+ 				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks to start the joining process", cs->client_id, 4 * DAY_TICKS);
+ 				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
+ 			}
++		} else if (cs->status == STATUS_MAP) {
++			/* Downloading the map... this is the amount of time since starting the saving. */
++			int lag = NetworkCalculateLag(cs);
++			if (lag > _settings_client.network.max_download_time) {
++				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks for him to download the map", cs->client_id, _settings_client.network.max_download_time);
++				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
++			}
++		} else if (cs->status == STATUS_AUTHORIZING) {
++			/* Waiting for the password. */
++			int lag = NetworkCalculateLag(cs);
++			if (lag > _settings_client.network.max_password_time) {
++				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks to enter the password", cs->client_id, _settings_client.network.max_password_time);
++				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
++			}
++		} else if (cs->status == STATUS_MAP_WAIT) {
++			/* This is an internal state where we do not wait
++			 * on the client to move to a different state. */
++		} else {
++			/* Bad server/code. */
++			NOT_REACHED();
+ 		}
+ 
+ 		if (cs->status >= STATUS_PRE_ACTIVE) {

--- a/_security/CVE-2012-0049/1.0.1 - 1.0.1.patch
+++ b/_security/CVE-2012-0049/1.0.1 - 1.0.1.patch
@@ -1,0 +1,84 @@
+---
+layout: security_patch
+cve: CVE-2012-0049
+first_version: 1.0.1
+last_version: 1.0.1
+---
+
+Index: src/table/settings.h
+===================================================================
+--- src/table/settings.h	(revision 19742)
++++ src/table/settings.h	(working copy)
+@@ -610,6 +610,8 @@
+ 	  SDTC_VAR(network.sync_freq,            SLE_UINT16,C|S,NO,   100,        0,      100, 0, STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.frame_freq,            SLE_UINT8,C|S,NO,     0,        0,      100, 0, STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.max_join_time,        SLE_UINT16, S, NO,   500,        0,    32000, 0, STR_NULL,                                       NULL),
++	  SDTC_VAR(network.max_download_time,    SLE_UINT16, S, NO,  1000,        0,    32000, 0, STR_NULL,                                       NULL),
++	  SDTC_VAR(network.max_password_time,    SLE_UINT16, S, NO,  2000,        0,    32000, 0, STR_NULL,                                       NULL),
+ 	 SDTC_BOOL(network.pause_on_join,                    S, NO,  true,                        STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.server_port,          SLE_UINT16, S, NO,NETWORK_DEFAULT_PORT,0,65535,0,STR_NULL,                                       NULL),
+ 	 SDTC_BOOL(network.server_advertise,                 S, NO, false,                        STR_NULL,                                       NULL),
+Index: src/settings_type.h
+===================================================================
+--- src/settings_type.h	(revision 19742)
++++ src/settings_type.h	(working copy)
+@@ -125,6 +125,8 @@
+ 	uint16 sync_freq;                                     ///< how often do we check whether we are still in-sync
+ 	uint8  frame_freq;                                    ///< how often do we send commands to the clients
+ 	uint16 max_join_time;                                 ///< maximum amount of time, in game ticks, a client may take to join
++	uint16 max_download_time;                             ///< maximum amount of time, in game ticks, a client may take to download the map
++	uint16 max_password_time;                             ///< maximum amount of time, in game ticks, a client may take to enter the password
+ 	bool   pause_on_join;                                 ///< pause the game when people join
+ 	uint16 server_port;                                   ///< port the server listens on
+ 	char   server_name[NETWORK_NAME_LENGTH];              ///< name of the server
+Index: src/network/network_server.cpp
+===================================================================
+--- src/network/network_server.cpp	(revision 19742)
++++ src/network/network_server.cpp	(working copy)
+@@ -1656,18 +1656,44 @@
+ 			} else {
+ 				cs->lag_test = 0;
+ 			}
+-		} else if (cs->status == STATUS_PRE_ACTIVE) {
++		} else if (cs->status == STATUS_DONE_MAP ||
++					cs->status == STATUS_PRE_ACTIVE) {
++			/* The map has been sent, so this is for loading the map and syncing up. */
+ 			int lag = NetworkCalculateLag(cs);
+ 			if (lag > _settings_client.network.max_join_time) {
+ 				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks for him to join", cs->client_id, _settings_client.network.max_join_time);
+ 				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
+ 			}
+-		} else if (cs->status == STATUS_INACTIVE) {
++		} else if (cs->status == STATUS_INACTIVE ||
++				cs->status == STATUS_AUTHORIZED) {
++			/* NewGRF check and authorized states should be handled almost instantly.
++			 * So give them some lee-way, likewise for the query with inactive. */
+ 			int lag = NetworkCalculateLag(cs);
+ 			if (lag > 4 * DAY_TICKS) {
+ 				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks to start the joining process", cs->client_id, 4 * DAY_TICKS);
+ 				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
+ 			}
++		} else if (cs->status == STATUS_MAP) {
++			/* Downloading the map... this is the amount of time since starting the saving. */
++			uint lag = NetworkCalculateLag(cs);
++			if (lag > _settings_client.network.max_download_time) {
++				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks for him to download the map", cs->client_id, _settings_client.network.max_download_time);
++				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
++			}
++		} else if (cs->status == STATUS_AUTH_GAME ||
++				cs->status == STATUS_AUTH_COMPANY) {
++			/* Waiting for the password. */
++			uint lag = NetworkCalculateLag(cs);
++			if (lag > _settings_client.network.max_password_time) {
++				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks to enter the password", cs->client_id, _settings_client.network.max_password_time);
++				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
++			}
++		} else if (cs->status == STATUS_MAP_WAIT) {
++			/* This is an internal state where we do not wait
++			 * on the client to move to a different state. */
++		} else {
++			/* Bad server/code. */
++			NOT_REACHED();
+ 		}
+ 
+ 		if (cs->status >= STATUS_PRE_ACTIVE) {

--- a/_security/CVE-2012-0049/1.0.2 - 1.0.5.patch
+++ b/_security/CVE-2012-0049/1.0.2 - 1.0.5.patch
@@ -1,0 +1,87 @@
+---
+layout: security_patch
+cve: CVE-2012-0049
+first_version: 1.0.2
+last_version: 1.0.5
+---
+
+Index: src/table/settings.h
+===================================================================
+--- src/table/settings.h	(revision 23768)
++++ src/table/settings.h	(working copy)
+@@ -611,6 +611,8 @@
+ 	  SDTC_VAR(network.sync_freq,            SLE_UINT16,C|S,NO,   100,        0,      100, 0, STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.frame_freq,            SLE_UINT8,C|S,NO,     0,        0,      100, 0, STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.max_join_time,        SLE_UINT16, S, NO,   500,        0,    32000, 0, STR_NULL,                                       NULL),
++	  SDTC_VAR(network.max_download_time,    SLE_UINT16, S, NO,  1000,        0,    32000, 0, STR_NULL,                                       NULL),
++	  SDTC_VAR(network.max_password_time,    SLE_UINT16, S, NO,  2000,        0,    32000, 0, STR_NULL,                                       NULL),
+ 	 SDTC_BOOL(network.pause_on_join,                    S, NO,  true,                        STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.server_port,          SLE_UINT16, S, NO,NETWORK_DEFAULT_PORT,0,65535,0,STR_NULL,                                       NULL),
+ 	 SDTC_BOOL(network.server_advertise,                 S, NO, false,                        STR_NULL,                                       NULL),
+Index: src/settings_type.h
+===================================================================
+--- src/settings_type.h	(revision 23768)
++++ src/settings_type.h	(working copy)
+@@ -125,6 +125,8 @@
+ 	uint16 sync_freq;                                     ///< how often do we check whether we are still in-sync
+ 	uint8  frame_freq;                                    ///< how often do we send commands to the clients
+ 	uint16 max_join_time;                                 ///< maximum amount of time, in game ticks, a client may take to join
++	uint16 max_download_time;                             ///< maximum amount of time, in game ticks, a client may take to download the map
++	uint16 max_password_time;                             ///< maximum amount of time, in game ticks, a client may take to enter the password
+ 	bool   pause_on_join;                                 ///< pause the game when people join
+ 	uint16 server_port;                                   ///< port the server listens on
+ 	char   server_name[NETWORK_NAME_LENGTH];              ///< name of the server
+Index: src/network/network_server.cpp
+===================================================================
+--- src/network/network_server.cpp	(revision 23768)
++++ src/network/network_server.cpp	(working copy)
+@@ -1658,18 +1658,45 @@
+ 			} else {
+ 				cs->lag_test = 0;
+ 			}
+-		} else if (cs->status == STATUS_PRE_ACTIVE) {
+-			int lag = NetworkCalculateLag(cs);
++		} else if (cs->status == STATUS_DONE_MAP ||
++					cs->status == STATUS_PRE_ACTIVE) {
++			/* The map has been sent, so this is for loading the map and syncing up. */
++			uint lag = NetworkCalculateLag(cs);
+ 			if (lag > _settings_client.network.max_join_time) {
+ 				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks for him to join", cs->client_id, _settings_client.network.max_join_time);
+ 				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
+ 			}
+-		} else if (cs->status == STATUS_INACTIVE) {
+-			int lag = NetworkCalculateLag(cs);
++		} else if (cs->status == STATUS_INACTIVE ||
++				cs->status == STATUS_NEWGRFS_CHECK ||
++				cs->status == STATUS_AUTHORIZED) {
++			/* NewGRF check and authorized states should be handled almost instantly.
++			 * So give them some lee-way, likewise for the query with inactive. */
++			uint lag = NetworkCalculateLag(cs);
+ 			if (lag > 4 * DAY_TICKS) {
+ 				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks to start the joining process", cs->client_id, 4 * DAY_TICKS);
+ 				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
+ 			}
++		} else if (cs->status == STATUS_MAP) {
++			/* Downloading the map... this is the amount of time since starting the saving. */
++			uint lag = NetworkCalculateLag(cs);
++			if (lag > _settings_client.network.max_download_time) {
++				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks for him to download the map", cs->client_id, _settings_client.network.max_download_time);
++				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
++			}
++		} else if (cs->status == STATUS_AUTH_GAME ||
++				cs->status == STATUS_AUTH_COMPANY) {
++			/* Waiting for the password. */
++			uint lag = NetworkCalculateLag(cs);
++			if (lag > _settings_client.network.max_password_time) {
++				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks to enter the password", cs->client_id, _settings_client.network.max_password_time);
++				NetworkCloseClient(cs, NETWORK_RECV_STATUS_SERVER_ERROR);
++			}
++		} else if (cs->status == STATUS_MAP_WAIT) {
++			/* This is an internal state where we do not wait
++			 * on the client to move to a different state. */
++		} else {
++			/* Bad server/code. */
++			NOT_REACHED();
+ 		}
+ 
+ 		if (cs->status >= STATUS_PRE_ACTIVE) {

--- a/_security/CVE-2012-0049/1.1.0 - 1.1.4.patch
+++ b/_security/CVE-2012-0049/1.1.0 - 1.1.4.patch
@@ -1,0 +1,89 @@
+---
+layout: security_patch
+cve: CVE-2012-0049
+first_version: 1.1.0
+last_version: 1.1.4
+---
+
+Index: src/table/settings.h
+===================================================================
+--- src/table/settings.h	(revision 23768)
++++ src/table/settings.h	(working copy)
+@@ -645,6 +645,8 @@
+ 	  SDTC_VAR(network.bytes_per_frame,      SLE_UINT16, S, NO,     8,        1,    65535, 0, STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.bytes_per_frame_burst,SLE_UINT16, S, NO,   256,        1,    65535, 0, STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.max_join_time,        SLE_UINT16, S, NO,   500,        0,    32000, 0, STR_NULL,                                       NULL),
++	  SDTC_VAR(network.max_download_time,    SLE_UINT16, S, NO,  1000,        0,    32000, 0, STR_NULL,                                       NULL),
++	  SDTC_VAR(network.max_password_time,    SLE_UINT16, S, NO,  2000,        0,    32000, 0, STR_NULL,                                       NULL),
+ 	 SDTC_BOOL(network.pause_on_join,                    S, NO,  true,                        STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.server_port,          SLE_UINT16, S, NO,NETWORK_DEFAULT_PORT,0,65535,0,STR_NULL,                                       NULL),
+ 	  SDTC_VAR(network.server_admin_port,    SLE_UINT16, S, NO,  NETWORK_ADMIN_PORT,0,65535,0,STR_NULL,                                       NULL),
+Index: src/settings_type.h
+===================================================================
+--- src/settings_type.h	(revision 23768)
++++ src/settings_type.h	(working copy)
+@@ -155,6 +155,8 @@
+ 	uint16 bytes_per_frame;                               ///< how many bytes may, over a long period, be received per frame?
+ 	uint16 bytes_per_frame_burst;                         ///< how many bytes may, over a short period, be received?
+ 	uint16 max_join_time;                                 ///< maximum amount of time, in game ticks, a client may take to join
++	uint16 max_download_time;                             ///< maximum amount of time, in game ticks, a client may take to download the map
++	uint16 max_password_time;                             ///< maximum amount of time, in game ticks, a client may take to enter the password
+ 	bool   pause_on_join;                                 ///< pause the game when people join
+ 	uint16 server_port;                                   ///< port the server listens on
+ 	uint16 server_admin_port;                             ///< port the server listens on for the admin network
+Index: src/network/network_server.cpp
+===================================================================
+--- src/network/network_server.cpp	(revision 23768)
++++ src/network/network_server.cpp	(working copy)
+@@ -1752,20 +1752,49 @@
+ 				cs->CloseConnection(NETWORK_RECV_STATUS_SERVER_ERROR);
+ 				continue;
+ 			}
+-		} else if (cs->status == NetworkClientSocket::STATUS_PRE_ACTIVE) {
++		} else if (cs->status == NetworkClientSocket::STATUS_DONE_MAP ||
++					cs->status == NetworkClientSocket::STATUS_PRE_ACTIVE) {
++			/* The map has been sent, so this is for loading the map and syncing up. */
+ 			uint lag = NetworkCalculateLag(cs);
+ 			if (lag > _settings_client.network.max_join_time) {
+ 				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks for him to join", cs->client_id, _settings_client.network.max_join_time);
+ 				cs->CloseConnection(NETWORK_RECV_STATUS_SERVER_ERROR);
+ 				continue;
+ 			}
+-		} else if (cs->status == NetworkClientSocket::STATUS_INACTIVE) {
++		} else if (cs->status == NetworkClientSocket::STATUS_INACTIVE ||
++				cs->status == NetworkClientSocket::STATUS_NEWGRFS_CHECK ||
++				cs->status == NetworkClientSocket::STATUS_AUTHORIZED) {
++			/* NewGRF check and authorized states should be handled almost instantly.
++			 * So give them some lee-way, likewise for the query with inactive. */
+ 			uint lag = NetworkCalculateLag(cs);
+ 			if (lag > 4 * DAY_TICKS) {
+ 				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks to start the joining process", cs->client_id, 4 * DAY_TICKS);
+ 				cs->CloseConnection(NETWORK_RECV_STATUS_SERVER_ERROR);
+ 				continue;
+ 			}
++		} else if (cs->status == NetworkClientSocket::STATUS_MAP) {
++			/* Downloading the map... this is the amount of time since starting the saving. */
++			uint lag = NetworkCalculateLag(cs);
++			if (lag > _settings_client.network.max_download_time) {
++				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks for him to download the map", cs->client_id, _settings_client.network.max_download_time);
++				cs->CloseConnection(NETWORK_RECV_STATUS_SERVER_ERROR);
++				continue;
++			}
++		} else if (cs->status == NetworkClientSocket::STATUS_AUTH_GAME ||
++				cs->status == NetworkClientSocket::STATUS_AUTH_COMPANY) {
++			/* Waiting for the password. */
++			uint lag = NetworkCalculateLag(cs);
++			if (lag > _settings_client.network.max_password_time) {
++				IConsolePrintF(CC_ERROR,"Client #%d is dropped because it took longer than %d ticks to enter the password", cs->client_id, _settings_client.network.max_password_time);
++				cs->CloseConnection(NETWORK_RECV_STATUS_SERVER_ERROR);
++				continue;
++			}
++		} else if (cs->status == NetworkClientSocket::STATUS_MAP_WAIT) {
++			/* This is an internal state where we do not wait
++			 * on the client to move to a different state. */
++		} else {
++			/* Bad server/code. */
++			NOT_REACHED();
+ 		}
+ 
+ 		if (cs->status >= NetworkClientSocket::STATUS_PRE_ACTIVE) {

--- a/_security/CVE-2012-3436.md
+++ b/_security/CVE-2012-3436.md
@@ -1,0 +1,52 @@
+---
+name: CVE-2012-3436
+description: Denial of service (server) using ships on half tiles and landscaping.
+first_vulnerable: 0.6.0
+first_fixed: 1.2.2
+related_bugs:
+- 5254
+related_commits:
+- 59a3bbc
+- e07e246
+patches:
+- name: For version 0.6.0 up to including 0.6.3
+  file: 0.6.0 - 0.6.3.patch
+- name: For version 0.7.0 up to including 0.7.5
+  file: 0.7.0 - 0.7.5.patch
+- name: For version 1.0.0 up to including 1.0.5
+  file: 1.0.0 - 1.0.5.patch
+- name: For version 1.1.0 up to including 1.1.5
+  file: 1.1.0 - 1.1.5.patch
+- name: For version 1.2.0 up to including 1.2.1
+  file: 1.2.0 - 1.2.1.patch
+---
+
+Denial of service using ships on half tiles and landscaping.
+
+Simple steps to reproduce the issue, and show the severity:
+1. start a new game. For this reproduction you do not need to start a server;
+   you can see the crash locally, but due to the nature of OpenTTD the crash
+   will also happen on the server you're playing on with multiplayer.
+1. build some horizontal or vertical track at the coast, so that half of the
+   tile remains water or coast. The tile should either have
+   one corner raised with flat water on one half tile (case 1)
+   or two adjacent corners raised with coast on the sloped half tile (case 2)
+1. build a ship depot, a ship and a dock at the coast, and start the ship
+1. obstruct the path of the ship in a way so that it enters the tile with half
+   railtrack and half water
+1. landscape the tile by raising the water corner while the ship is on it
+   (only needed in case 1)
+1. both cases will make the ship end up on land
+1. remove the track using the "remove track" tool while the ship is on the tile
+1. server segfaults due to NULL pointer dereference.
+
+The problem is caused by incorrectly handling the water/coast aspect of tiles
+which also have railtracks on one half.
+The fix adds the correct checks to the landscaping and movement code.
+
+If you try to reproduce this with the patch applied you'll see that,
+in case 1, step 5 will deny the terraforming and in case 2 the ship simply
+won't try to enter the coast tile.
+
+This bug was triggered incidentally by a user playing online when landscaping
+near a ship. We have not seen any signs of this bug being exploited forcefully.

--- a/_security/CVE-2012-3436/0.6.0 - 0.6.3.patch
+++ b/_security/CVE-2012-3436/0.6.0 - 0.6.3.patch
@@ -1,0 +1,45 @@
+---
+layout: security_patch
+cve: CVE-2012-3436
+first_version: 0.6.0
+last_version: 0.6.3
+---
+
+Index: src/rail_cmd.cpp
+===================================================================
+--- src/rail_cmd.cpp	(revision 24106)
++++ src/rail_cmd.cpp	(working copy)
+@@ -2103,7 +2103,7 @@
+ static TrackStatus GetTileTrackStatus_Track(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side)
+ {
+ 	/* Case of half tile slope with water. */
+-	if (mode == TRANSPORT_WATER && IsPlainRailTile(tile) && GetRailGroundType(tile) == RAIL_GROUND_WATER) {
++	if (mode == TRANSPORT_WATER && IsPlainRailTile(tile) && GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(GetTileSlope(tile, NULL))) {
+ 		TrackBits tb = GetTrackBits(tile);
+ 		switch (tb) {
+ 			default: NOT_REACHED();
+@@ -2367,6 +2367,14 @@
+ 	return  cost;
+ }
+ 
++/**
++ * Test-procedure for HasVehicleOnPos to check for a ship.
++ */
++static void *EnsureNoShipProc(Vehicle *v, void *data)
++{
++	return v->type == VEH_SHIP ? v : NULL;
++}
++
+ static CommandCost TerraformTile_Track(TileIndex tile, uint32 flags, uint z_new, Slope tileh_new)
+ {
+ 	uint z_old;
+@@ -2376,6 +2384,9 @@
+ 		/* Is there flat water on the lower halftile, that must be cleared expensively? */
+ 		bool was_water = (GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(tileh_old));
+ 
++		/* Allow clearing the water only if there is no ship */
++		if (was_water && HasVehicleOnPos(tile, NULL, &EnsureNoShipProc)) return_cmd_error(STR_980E_SHIP_IN_THE_WAY);
++
+ 		_error_message = STR_1008_MUST_REMOVE_RAILROAD_TRACK;
+ 
+ 		/* First test autoslope. However if it succeeds we still have to test the rest, because non-autoslope terraforming is cheaper. */

--- a/_security/CVE-2012-3436/0.7.0 - 0.7.5.patch
+++ b/_security/CVE-2012-3436/0.7.0 - 0.7.5.patch
@@ -1,0 +1,45 @@
+---
+layout: security_patch
+cve: CVE-2012-3436
+first_version: 0.7.0
+last_version: 0.7.5
+---
+
+Index: src/rail_cmd.cpp
+===================================================================
+--- src/rail_cmd.cpp	(revision 24439)
++++ src/rail_cmd.cpp	(working copy)
+@@ -2248,7 +2248,7 @@
+ static TrackStatus GetTileTrackStatus_Track(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side)
+ {
+ 	/* Case of half tile slope with water. */
+-	if (mode == TRANSPORT_WATER && IsPlainRail(tile) && GetRailGroundType(tile) == RAIL_GROUND_WATER) {
++	if (mode == TRANSPORT_WATER && IsPlainRail(tile) && GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(GetTileSlope(tile, NULL))) {
+ 		TrackBits tb = GetTrackBits(tile);
+ 		switch (tb) {
+ 			default: NOT_REACHED();
+@@ -2547,6 +2547,14 @@
+ 	return  cost;
+ }
+ 
++/**
++ * Test-procedure for HasVehicleOnPos to check for a ship.
++ */
++static Vehicle *EnsureNoShipProc(Vehicle *v, void *data)
++{
++	return v->type == VEH_SHIP ? v : NULL;
++}
++
+ static CommandCost TerraformTile_Track(TileIndex tile, DoCommandFlag flags, uint z_new, Slope tileh_new)
+ {
+ 	uint z_old;
+@@ -2556,6 +2564,9 @@
+ 		/* Is there flat water on the lower halftile, that must be cleared expensively? */
+ 		bool was_water = (GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(tileh_old));
+ 
++		/* Allow clearing the water only if there is no ship */
++		if (was_water && HasVehicleOnPos(tile, NULL, &EnsureNoShipProc)) return_cmd_error(STR_980E_SHIP_IN_THE_WAY);
++
+ 		_error_message = STR_1008_MUST_REMOVE_RAILROAD_TRACK;
+ 
+ 		/* First test autoslope. However if it succeeds we still have to test the rest, because non-autoslope terraforming is cheaper. */

--- a/_security/CVE-2012-3436/1.0.0 - 1.0.5.patch
+++ b/_security/CVE-2012-3436/1.0.0 - 1.0.5.patch
@@ -1,0 +1,45 @@
+---
+layout: security_patch
+cve: CVE-2012-3436
+first_version: 1.0.0
+last_version: 1.0.5
+---
+
+Index: src/rail_cmd.cpp
+===================================================================
+--- src/rail_cmd.cpp	(revision 22030)
++++ src/rail_cmd.cpp	(working copy)
+@@ -2470,7 +2470,7 @@
+ static TrackStatus GetTileTrackStatus_Track(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side)
+ {
+ 	/* Case of half tile slope with water. */
+-	if (mode == TRANSPORT_WATER && IsPlainRail(tile) && GetRailGroundType(tile) == RAIL_GROUND_WATER) {
++	if (mode == TRANSPORT_WATER && IsPlainRail(tile) && GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(GetTileSlope(tile, NULL))) {
+ 		TrackBits tb = GetTrackBits(tile);
+ 		switch (tb) {
+ 			default: NOT_REACHED();
+@@ -2768,6 +2768,14 @@
+ 	return  cost;
+ }
+ 
++/**
++ * Test-procedure for HasVehicleOnPos to check for a ship.
++ */
++static Vehicle *EnsureNoShipProc(Vehicle *v, void *data)
++{
++	return v->type == VEH_SHIP ? v : NULL;
++}
++
+ static CommandCost TerraformTile_Track(TileIndex tile, DoCommandFlag flags, uint z_new, Slope tileh_new)
+ {
+ 	uint z_old;
+@@ -2777,6 +2785,9 @@
+ 		/* Is there flat water on the lower halftile, that must be cleared expensively? */
+ 		bool was_water = (GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(tileh_old));
+ 
++		/* Allow clearing the water only if there is no ship */
++		if (was_water && HasVehicleOnPos(tile, NULL, &EnsureNoShipProc)) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
++
+ 		_error_message = STR_ERROR_MUST_REMOVE_RAILROAD_TRACK;
+ 
+ 		/* First test autoslope. However if it succeeds we still have to test the rest, because non-autoslope terraforming is cheaper. */

--- a/_security/CVE-2012-3436/1.1.0 - 1.1.5.patch
+++ b/_security/CVE-2012-3436/1.1.0 - 1.1.5.patch
@@ -1,0 +1,45 @@
+---
+layout: security_patch
+cve: CVE-2012-3436
+first_version: 1.1.0
+last_version: 1.1.5
+---
+
+Index: src/rail_cmd.cpp
+===================================================================
+--- src/rail_cmd.cpp	(revision 23811)
++++ src/rail_cmd.cpp	(working copy)
+@@ -2527,7 +2527,7 @@
+ static TrackStatus GetTileTrackStatus_Track(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side)
+ {
+ 	/* Case of half tile slope with water. */
+-	if (mode == TRANSPORT_WATER && IsPlainRail(tile) && GetRailGroundType(tile) == RAIL_GROUND_WATER) {
++	if (mode == TRANSPORT_WATER && IsPlainRail(tile) && GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(GetTileSlope(tile, NULL))) {
+ 		TrackBits tb = GetTrackBits(tile);
+ 		switch (tb) {
+ 			default: NOT_REACHED();
+@@ -2831,6 +2831,14 @@
+ 	return  cost;
+ }
+ 
++/**
++ * Test-procedure for HasVehicleOnPos to check for a ship.
++ */
++static Vehicle *EnsureNoShipProc(Vehicle *v, void *data)
++{
++	return v->type == VEH_SHIP ? v : NULL;
++}
++
+ static CommandCost TerraformTile_Track(TileIndex tile, DoCommandFlag flags, uint z_new, Slope tileh_new)
+ {
+ 	uint z_old;
+@@ -2840,6 +2848,9 @@
+ 		/* Is there flat water on the lower halftile that must be cleared expensively? */
+ 		bool was_water = (GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(tileh_old));
+ 
++		/* Allow clearing the water only if there is no ship */
++		if (was_water && HasVehicleOnPos(tile, NULL, &EnsureNoShipProc)) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
++
+ 		/* First test autoslope. However if it succeeds we still have to test the rest, because non-autoslope terraforming is cheaper. */
+ 		CommandCost autoslope_result = TestAutoslopeOnRailTile(tile, flags, z_old, tileh_old, z_new, tileh_new, rail_bits);
+ 

--- a/_security/CVE-2012-3436/1.2.0 - 1.2.1.patch
+++ b/_security/CVE-2012-3436/1.2.0 - 1.2.1.patch
@@ -1,0 +1,45 @@
+---
+layout: security_patch
+cve: CVE-2012-3436
+first_version: 1.2.0
+last_version: 1.2.1
+---
+
+Index: src/rail_cmd.cpp
+===================================================================
+--- src/rail_cmd.cpp	(revision 24373)
++++ src/rail_cmd.cpp	(working copy)
+@@ -2604,7 +2604,7 @@
+ static TrackStatus GetTileTrackStatus_Track(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side)
+ {
+ 	/* Case of half tile slope with water. */
+-	if (mode == TRANSPORT_WATER && IsPlainRail(tile) && GetRailGroundType(tile) == RAIL_GROUND_WATER) {
++	if (mode == TRANSPORT_WATER && IsPlainRail(tile) && GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(GetTileSlope(tile))) {
+ 		TrackBits tb = GetTrackBits(tile);
+ 		switch (tb) {
+ 			default: NOT_REACHED();
+@@ -2925,6 +2925,14 @@
+ 	return  cost;
+ }
+ 
++/**
++ * Test-procedure for HasVehicleOnPos to check for a ship.
++ */
++static Vehicle *EnsureNoShipProc(Vehicle *v, void *data)
++{
++	return v->type == VEH_SHIP ? v : NULL;
++}
++
+ static CommandCost TerraformTile_Track(TileIndex tile, DoCommandFlag flags, int z_new, Slope tileh_new)
+ {
+ 	int z_old;
+@@ -2934,6 +2942,9 @@
+ 		/* Is there flat water on the lower halftile that must be cleared expensively? */
+ 		bool was_water = (GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(tileh_old));
+ 
++		/* Allow clearing the water only if there is no ship */
++		if (was_water && HasVehicleOnPos(tile, NULL, &EnsureNoShipProc)) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
++
+ 		/* First test autoslope. However if it succeeds we still have to test the rest, because non-autoslope terraforming is cheaper. */
+ 		CommandCost autoslope_result = TestAutoslopeOnRailTile(tile, flags, z_old, tileh_old, z_new, tileh_new, rail_bits);
+ 

--- a/_security/CVE-2013-6411.md
+++ b/_security/CVE-2013-6411.md
@@ -1,0 +1,46 @@
+---
+name: CVE-2013-6411
+description: Denial of service (server) using forcefully crashed aircrafts.
+first_vulnerable: 0.3.6
+first_fixed: 1.3.3
+related_bugs:
+- 5820
+related_commits:
+- aa8f9e2
+patches:
+- name: For version 1.2.0 up to including 1.3.2
+  file: 1.2.0 - 1.3.2.patch
+- name: For version 1.0.0 up to including 1.1.5
+  file: 1.0.0 - 1.1.5.patch
+- name: For version 0.6.0 up to including 0.7.3
+  file: 0.6.0 - 0.7.3.patch
+- name: For version 0.3.6 up to including 0.5.3
+  file: 0.3.6 - 0.5.3.patch
+---
+
+Denial of service using aircrafts that are forcefully crashed.
+
+Simple steps to reproduce the issue, and show the severity:
+1. Start a new game. For this reproduction you do not need to start a server;
+   you can see the crash locally, but due to the nature of OpenTTD the crash
+   will also happen on the server you're playing on in multiplayer
+1. Build an airport at the map corner and join it with rail station
+1. Make this airport the order destination for planes which will start 
+   from another place, or use the close airport feature, and then they may 
+   also start from the same airport
+1. Wait until all planes are sky high and rotating around the corner airport
+1. In case aircraft are launched from another airport, remove that airport
+1. Remove the airport part of the corner airport, and leave only the rail station
+1. Remove the rail station part
+1. Wait for the aircraft to keep circling and eventually crash due to lack of fuel
+1. Server segfaults due to invalid memory access (stable releases), or triggering 
+   of an assertion (most other builds)
+
+The problem is caused by incorrectly handling the fact that the aircraft circling the
+corner airport will be outside of the bounds of the map. In the 'out of fuel' crash
+code the height of the tile under the aircraft is determined. In this case that means
+a tile outside of the allocated map array, which could occasionally trigger invalid
+reads.
+
+The fix makes sure the height of the map border is used when the aircraft is outside
+of the map.

--- a/_security/CVE-2013-6411/0.3.6 - 0.5.3.patch
+++ b/_security/CVE-2013-6411/0.3.6 - 0.5.3.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2013-6411
+first_version: 0.3.6
+last_version: 0.5.3
+---
+
+Index: aircraft_cmd.c
+===================================================================
+--- aircraft_cmd.c	(revision 25160)
++++ aircraft_cmd.c	(working copy)
+@@ -1102,7 +1102,7 @@
+ 
+ 	// make aircraft crash down to the ground
+ 	if (v->u.air.crashed_counter < 500 && st->airport_tile==0 && ((v->u.air.crashed_counter % 3) == 0) ) {
+-		z = GetSlopeZ(v->x_pos, v->y_pos);
++		z = GetSlopeZ(clamp(v->x_pos, 0, MapMaxX() * TILE_SIZE), clamp(v->y_pos, 0, MapMaxY() * TILE_SIZE));
+ 		v->z_pos -= 1;
+ 		if (v->z_pos == z) {
+ 			v->u.air.crashed_counter = 500;

--- a/_security/CVE-2013-6411/0.6.0 - 0.7.3.patch
+++ b/_security/CVE-2013-6411/0.6.0 - 0.7.3.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2013-6411
+first_version: 0.6.0
+last_version: 0.7.3
+---
+
+Index: src/aircraft_cmd.cpp
+===================================================================
+--- src/aircraft_cmd.cpp	(revision 25754)
++++ src/aircraft_cmd.cpp	(working copy)
+@@ -1157,7 +1157,7 @@
+ 
+ 	/* make aircraft crash down to the ground */
+ 	if (v->u.air.crashed_counter < 500 && st == NULL && ((v->u.air.crashed_counter % 3) == 0) ) {
+-		uint z = GetSlopeZ(v->x_pos, v->y_pos);
++		uint z = GetSlopeZ(Clamp(v->x_pos, 0, MapMaxX() * TILE_SIZE), Clamp(v->y_pos, 0, MapMaxY() * TILE_SIZE));
+ 		v->z_pos -= 1;
+ 		if (v->z_pos == z) {
+ 			v->u.air.crashed_counter = 500;

--- a/_security/CVE-2013-6411/1.0.0 - 1.1.5.patch
+++ b/_security/CVE-2013-6411/1.0.0 - 1.1.5.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2013-6411
+first_version: 1.0.0
+last_version: 1.1.5
+---
+
+Index: src/aircraft_cmd.cpp
+===================================================================
+--- src/aircraft_cmd.cpp	(revision 25160)
++++ src/aircraft_cmd.cpp	(working copy)
+@@ -988,7 +988,7 @@
+ 
+ 	/* make aircraft crash down to the ground */
+ 	if (v->crashed_counter < 500 && st == NULL && ((v->crashed_counter % 3) == 0) ) {
+-		uint z = GetSlopeZ(v->x_pos, v->y_pos);
++		int z = GetSlopeZ(Clamp(v->x_pos, 0, MapMaxX() * TILE_SIZE), Clamp(v->y_pos, 0, MapMaxY() * TILE_SIZE));
+ 		v->z_pos -= 1;
+ 		if (v->z_pos == z) {
+ 			v->crashed_counter = 500;

--- a/_security/CVE-2013-6411/1.2.0 - 1.3.2.patch
+++ b/_security/CVE-2013-6411/1.2.0 - 1.3.2.patch
@@ -1,0 +1,20 @@
+---
+layout: security_patch
+cve: CVE-2013-6411
+first_version: 1.2.0
+last_version: 1.3.2
+---
+
+Index: src/aircraft_cmd.cpp
+===================================================================
+--- src/aircraft_cmd.cpp	(revision 26133)
++++ src/aircraft_cmd.cpp	(working copy)
+@@ -1021,7 +1021,7 @@
+ 
+ 	/* make aircraft crash down to the ground */
+ 	if (v->crashed_counter < 500 && st == NULL && ((v->crashed_counter % 3) == 0) ) {
+-		int z = GetSlopePixelZ(v->x_pos, v->y_pos);
++		int z = GetSlopePixelZ(Clamp(v->x_pos, 0, MapMaxX() * TILE_SIZE), Clamp(v->y_pos, 0, MapMaxY() * TILE_SIZE));
+ 		v->z_pos -= 1;
+ 		if (v->z_pos == z) {
+ 			v->crashed_counter = 500;

--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -13,6 +13,11 @@ server {
     listen       80;
     server_name  localhost;
 
+    include mime.types;
+    types {
+        text/plain patch;
+    }
+
     # Redirect index.html requests to their root
     if ($request_uri ~ ^(.*)index.html$) { return 301 $scheme://$http_host$1; }
     # The screenshots folder has no index.html, so redirect it to the overview

--- a/pages/security.html
+++ b/pages/security.html
@@ -1,0 +1,46 @@
+---
+layout: default
+title: Security
+active_nav: security
+permalink: /security.html
+css:
+    - vuln.css
+---
+
+<div id="section-full">
+    <div class="section-header">
+        <h3>Security tracker</h3>
+    </div>
+    <div class="section-item">
+        <div class="content">
+            <p>
+                This page lists all known vulnerabilities of OpenTTD with an explanation and patches for vulnerable versions.
+            </p>
+            <p>
+                The list given here is by no means a full list of vulnerabilities.
+                Many vulnerabilities might have been fixed without us being aware of it being a vulnerability in the first place.
+                The list does contain all vulnerabilities that have a CVE number.
+            </p>
+            <p>
+                Even though we provide some patches for older versions, we advise to use newer versions of OpenTTD.
+            </p>
+            <table id="vuln-table">
+                <tr>
+                    <th class="name">name</th>
+                    <th class="description">description</th>
+                    <th class="first_vuln">first vulnerable</th>
+                    <th class="first_fixed">first fixed</th>
+                </tr>
+            {% assign security_reverse = site.security | where_exp: "item", "item.name" | reverse %}
+            {% for security in security_reverse %}
+                <tr class="{% cycle 'odd', 'even' %}">
+                    <td><a href="{{ site.baseurl }}{{ security.url }}">{{ security.name }}</td>
+                    <td>{{ security.description }}</td>
+                    <td>{{ security.first_vulnerable }}</td>
+                    <td>{{ security.first_fixed }}</td>
+                </tr>
+            {% endfor %}
+            </table>
+        </div>
+    </div>
+</div>

--- a/static/css/vuln.css
+++ b/static/css/vuln.css
@@ -1,0 +1,58 @@
+
+#vuln-info-table {
+	font-size: 12px;
+}
+
+#vuln-table {
+	font-size: 12px;
+	table-layout: fixed;
+	width: 738px;
+}
+
+#vuln-table th {
+	text-align: left;
+	text-decoration: underline;
+}
+#vuln-table td, #vuln-info-table td, #vuln-info-table th {
+	border-bottom: 1px solid #FFFFFF;
+	border-top: 1px solid #FFFFFF;
+	padding: 1px 3px 1px 3px;
+	text-align: left;
+}
+
+#vuln-table .odd, #vuln-info-table .odd {
+	background-color: #EEEEEE;
+}
+#vuln-table .even, #vuln-info-table .even {
+	background-color: #FFFFFF;
+}
+#vuln-table tr.odd:hover, #vuln-table tr.even:hover, #vuln-info-table tr.odd:hover, #vuln-info-table tr.even:hover, #vuln-table tr.odd:hover td, #vuln-table tr.even:hover td {
+	background-color: #CCCCCC;
+	border-bottom: 1px dashed #000000;
+	border-top: 1px dashed #000000;
+}
+
+#vuln-table .image {
+	background-color: #FFFFFF;
+	border-bottom: 1px solid #FFFFFF;
+	border-top: 1px solid #FFFFFF;
+}
+
+#vuln-table .odd:hover .image, #vuln-table .even:hover .image {
+	background-color: #FFFFFF;
+	border-bottom: 1px dashed #000000;
+	border-top: 1px dashed #000000;
+}
+
+#vuln-table .name {
+	width: 100px;
+}
+#vuln-table .description {
+	width: 500px;
+}
+#vuln-table .first_vuln {
+	width: 90px;
+}
+#vuln-table .first_fixed {
+	width: 60px;
+}


### PR DESCRIPTION
Instead of running on its own site, it now integrates with the
main website. This avoids copying the Jekyll website and maintaining
two instances of it. The main website and the CVE listing are similar
enough that this shouldn't be an issue.

The data is imported from the current security listing we have,
including the patches available. It is imported as-is without
modification.

**NOTE** : when reviewing, please run the Docker locally and test out if it is all what it should be.

Why via Docker and not via Jekyll `serve`? Otherwise `.patch` files will download, instead of showing it inline. Makes it a tiny bit harder to see what is going on.

The "diff" has a few files before all the `_security` related files start, and ends with 3 non-`_security` files at the bottom. Keep that in mind when reviewing.