### PR TITLE
Fix: also install ruby-etc in order for "gem update" to work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apk --no-cache add \
         ruby \
         ruby-bigdecimal \
         ruby-dev \
+        ruby-etc \
         ruby-json \
         ruby-rdoc \
     && echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc \


### PR DESCRIPTION
Completely unexpected, all of a sudden we need an additional
depenendency for "gem update" to work. We don't know why or when,
all we know the Docker no longer wants to build. This fixes the
problem.