### PR TITLE
Fix: Add Universal description for modern macOS binaries

### DIFF
--- a/_data/download-descriptions.yml
+++ b/_data/download-descriptions.yml
@@ -200,6 +200,8 @@ linux-ubuntu-xenial-i386-dbg.deb:
   description: Debug Symbols for Linux Ubuntu Xenial 16.04 (i386, 32 bit)
 linux-ubuntu-xenial-i386.deb:
   description: Linux Ubuntu Xenial 16.04 (i386, 32 bit)
+macos-universal.dmg:
+  description: macOS 10.9+ (Universal)
 macosx-i686.zip:
   description: Mac OS X 10.4-10.5 (Intel build)
 macosx-arm64.dmg:


### PR DESCRIPTION
Refer to "macOS" and label the binaries as universal.