### PR TITLE
Feature: List Windows ARM64 binaries correctly, autodetect ARM64 Windows

### DIFF
--- a/_data/download-descriptions.yml
+++ b/_data/download-descriptions.yml
@@ -246,6 +246,10 @@ source.zip:
   description: Sources (zip archive)
 win.zip:
   description: Headers/libraries to compile with MSVC for Windows
+windows-arm64.exe:
+  description: Windows 10 (ARM64) (installer)
+windows-arm64.zip:
+  description: Windows 10 (ARM64) (zip archive)
 windows-win32.exe:
   description: Windows XP with SP3 / Vista / 7 / 8 / 10 (32bit) (installer)
 windows-win32.pdb.xz:

--- a/static/js/download.js
+++ b/static/js/download.js
@@ -150,6 +150,7 @@ function detectByUA(state, base_name)
 					}
 					break;
 				case "amd64": match = "windows-win64"; break;
+				case "arm64": match = "windows-arm64"; break;
 				default: match = "windows"; break;
 			}
 			break;


### PR DESCRIPTION
This displays a description for ARM64 binaries (Windows 10) and also adds autodetection, which unlike on Mac should actually work...