### PR TITLE
Fix: Autodetect macOS correctly

### DIFF
--- a/static/js/download.js
+++ b/static/js/download.js
@@ -154,7 +154,7 @@ function detectByUA(state, base_name)
 			}
 			break;
 
-		case "Mac OS": match = "macosx"; break;
+		case "Mac OS": match = "macos"; break;
 		case "BeOS": match = "beos"; break;
 		case "Morph OS": match = "morphos"; break;
 		case "Debian": match = "linux-debian"; break;


### PR DESCRIPTION
We renamed "macosx" to "macos" but I missed this change, sorry.

The only potential issue I can see is that this may break the detection on the stable build (until we release 1.11), but there's only one macos image anyway so it shouldn't be hard for users to pick the right one.