### PR TITLE
Fix: Windows XP is no longer supported

### DIFF
--- a/_data/download-descriptions.yml
+++ b/_data/download-descriptions.yml
@@ -253,17 +253,17 @@ windows-arm64.pdb.xz:
 windows-arm64.zip:
   description: Windows 10 (ARM64) (zip archive)
 windows-win32.exe:
-  description: Windows XP with SP3 / Vista / 7 / 8 / 10 (32bit) (installer)
+  description: Windows Vista / 7 / 8 / 10 (32-bit) (installer)
 windows-win32.pdb.xz:
-  description: Debug Symbols for Windows (32bit) (xz/lzma archive)
+  description: Debug Symbols for Windows (32-bit) (xz/lzma archive)
 windows-win32.zip:
-  description: Windows XP with SP3 / Vista / 7 / 8 / 10 (32bit) (zip archive)
+  description: Windows Vista / 7 / 8 / 10 (32-bit) (zip archive)
 windows-win64.exe:
-  description: Windows XP / Vista / 7 / 8 / 10 (64bit) (installer)
+  description: Windows Vista / 7 / 8 / 10 (64-bit) (installer)
 windows-win64.pdb.xz:
-  description: Debug Symbols for Windows (64bit) (xz/lzma archive)
+  description: Debug Symbols for Windows (64-bit) (xz/lzma archive)
 windows-win64.zip:
-  description: Windows XP / Vista / 7 / 8 / 10 (64bit) (zip archive)
+  description: Windows Vista / 7 / 8 / 10 (64-bit) (zip archive)
 windows-win9x.exe:
   description: Windows 95 / 98 / ME / 2000 / XP without SP3 (installer)
 windows-win9x.zip:


### PR DESCRIPTION
Our builds no longer function on Windows XP. XP has been out of support and is 20 years old this year. We didn't support Windows 2.0 in 2005, so I don't think we need to support Windows 5.1 in 2021!