### PR TITLE
Change: Make it clearer that macOS 11 is supported

### DIFF
--- a/_data/download-descriptions.yml
+++ b/_data/download-descriptions.yml
@@ -201,9 +201,9 @@ linux-ubuntu-xenial-i386-dbg.deb:
 linux-ubuntu-xenial-i386.deb:
   description: Linux Ubuntu Xenial 16.04 (i386, 32 bit)
 macos-universal.dmg:
-  description: macOS 10.9+ (Intel / Apple Silicon) (disk image)
+  description: macOS 10.9+ / 11 (Big Sur) (Intel / Apple Silicon) (disk image)
 macos-universal.zip:
-  description: macOS 10.9+ (Intel / Apple Silicon) (zip archive)
+  description: macOS 10.9+ / 11 (Big Sur) (Intel / Apple Silicon) (zip archive)
 macosx-i686.zip:
   description: Mac OS X 10.4-10.5 (Intel build)
 macosx-arm64.dmg:

--- a/_data/download-descriptions.yml
+++ b/_data/download-descriptions.yml
@@ -201,9 +201,9 @@ linux-ubuntu-xenial-i386-dbg.deb:
 linux-ubuntu-xenial-i386.deb:
   description: Linux Ubuntu Xenial 16.04 (i386, 32 bit)
 macos-universal.dmg:
-  description: macOS 10.9+ (Universal) (disk image)
+  description: macOS 10.9+, 11+ (Universal) (disk image)
 macos-universal.zip:
-  description: macOS 10.9+ (Universal) (zip archive)
+  description: macOS 10.9+, 11+ (Universal) (zip archive)
 macosx-i686.zip:
   description: Mac OS X 10.4-10.5 (Intel build)
 macosx-arm64.dmg:

--- a/_data/download-descriptions.yml
+++ b/_data/download-descriptions.yml
@@ -201,9 +201,9 @@ linux-ubuntu-xenial-i386-dbg.deb:
 linux-ubuntu-xenial-i386.deb:
   description: Linux Ubuntu Xenial 16.04 (i386, 32 bit)
 macos-universal.dmg:
-  description: macOS 10.9+, 11+ (Universal) (disk image)
+  description: macOS 10.9+ / 11+ (Universal: Intel / Apple Silicon) (disk image)
 macos-universal.zip:
-  description: macOS 10.9+, 11+ (Universal) (zip archive)
+  description: macOS 10.9+ / 11+ (Universal: Intel / Apple Silicon) (zip archive)
 macosx-i686.zip:
   description: Mac OS X 10.4-10.5 (Intel build)
 macosx-arm64.dmg:

--- a/_data/download-descriptions.yml
+++ b/_data/download-descriptions.yml
@@ -201,9 +201,9 @@ linux-ubuntu-xenial-i386-dbg.deb:
 linux-ubuntu-xenial-i386.deb:
   description: Linux Ubuntu Xenial 16.04 (i386, 32 bit)
 macos-universal.dmg:
-  description: macOS 10.9+ / 11+ (Universal: Intel / Apple Silicon) (disk image)
+  description: macOS 10.9+ (Intel / Apple Silicon) (disk image)
 macos-universal.zip:
-  description: macOS 10.9+ / 11+ (Universal: Intel / Apple Silicon) (zip archive)
+  description: macOS 10.9+ (Intel / Apple Silicon) (zip archive)
 macosx-i686.zip:
   description: Mac OS X 10.4-10.5 (Intel build)
 macosx-arm64.dmg:


### PR DESCRIPTION
Just had a query whether macOS 11/M1 was supported by the new universal builds. Make it clear that this is the case.

Bikeshedding!

![image](https://user-images.githubusercontent.com/4007992/109036823-ea80b000-76c1-11eb-87df-12e8364e3b38.png)
