### PR TITLE
Add: rework our "Contact" page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ collections:
     output: true
   download-meta:
     output: false
-  people:
+  contact:
     output: false
   posts:
     permalink: /news/:year/:month/:day/:title.html

--- a/_contact/abuse.md
+++ b/_contact/abuse.md
@@ -1,0 +1,10 @@
+---
+name: Abuse
+sort_priority: 5
+locations:
+- name: Email
+  caption: abuse@openttd.org
+  link: "mailto:abuse@openttd.org"
+---
+
+Copyright infringement or other abuse-related information we should be aware of.

--- a/_contact/bugs.md
+++ b/_contact/bugs.md
@@ -1,0 +1,10 @@
+---
+name: Bugs and other issues
+sort_priority: 2
+locations:
+- name: Issues
+  caption: GitHub
+  link: https://github.com/OpenTTD/OpenTTD/issues
+---
+
+Game crashed? Found a graphical glitch? Functionality not working as expected? Please report your bug!

--- a/_contact/development.md
+++ b/_contact/development.md
@@ -1,0 +1,16 @@
+---
+name: Development
+sort_priority: 4
+locations:
+- name: IRC
+  caption: "OFTC / #openttd"
+  link: https://webchat.oftc.net/?channels=openttd
+- name: Source Code
+  caption: GitHub
+  link: https://github.com/OpenTTD/OpenTTD
+- name: Pull Requests / Patches
+  caption: GitHub
+  link: https://github.com/OpenTTD/OpenTTD/pulls
+---
+
+Development related questions, code improvements, etc.

--- a/_contact/features.md
+++ b/_contact/features.md
@@ -1,0 +1,10 @@
+---
+name: Feature requests
+sort_priority: 3
+locations:
+- name: Forum
+  caption: tt-forums.net
+  link: https://www.tt-forums.net/viewforum.php?f=32
+---
+
+Missing a feature? Have a cool idea?

--- a/_contact/general.md
+++ b/_contact/general.md
@@ -1,0 +1,12 @@
+---
+name: General contact
+sort_priority: 100
+locations:
+- name: Email
+  caption: info@openttd.org
+  link: "mailto:info@openttd.org"
+---
+
+Any question not answered by the list above? Contact us!
+
+(please mind: for support questions, use any of the links above. This email-address is not meant for support related questions!)

--- a/_contact/questions.md
+++ b/_contact/questions.md
@@ -1,0 +1,18 @@
+---
+name: Questions and player support
+sort_priority: 1
+locations:
+- name: Forum
+  caption: tt-forums.net
+  link: https://www.tt-forums.net/viewforum.php?f=31
+- name: Discord
+  caption: OpenTTD's Discord
+  link: https://discord.gg/hKzMGUx
+- name: Reddit
+  caption: /r/openttd/
+  link: https://www.reddit.com/r/openttd/
+---
+
+Generic questions about how to install and/or how to play the game, including how to setup multiplayer game, how signals work, etc.
+
+Please note that the developers currently working on OpenTTD don't follow these communities closely. See below how best to report issues.

--- a/_people/abuse.md
+++ b/_people/abuse.md
@@ -1,5 +1,0 @@
----
-name: Abuse Contact (Copyright Infringement, ..)
-email: abuse@openttd.org
-sort_priority: 1
----

--- a/_people/adf88.md
+++ b/_people/adf88.md
@@ -1,5 +1,0 @@
----
-name: Grzegorz Duczyński
-role: General Coding
-nick: adf88
----

--- a/_people/alberth.md
+++ b/_people/alberth.md
@@ -1,6 +1,0 @@
----
-name: Albert Hofkamp
-email: alberth@openttd.org
-role: GUI
-nick: Alberth
----

--- a/_people/belugas.md
+++ b/_people/belugas.md
@@ -1,5 +1,0 @@
----
-name: Jean-François Claeys
-role: NewGRF, General Coding
-nick: Belugas
----

--- a/_people/frosch.md
+++ b/_people/frosch.md
@@ -1,6 +1,0 @@
----
-name: Christoph Elsenhans
-email: frosch@openttd.org
-role: General Coding
-nick: frosch
----

--- a/_people/general.md
+++ b/_people/general.md
@@ -1,5 +1,0 @@
----
-name: General Information
-email: info@openttd.org
-sort_priority: 0
----

--- a/_people/glx.md
+++ b/_people/glx.md
@@ -1,6 +1,0 @@
----
-name: Loïc Guilloux
-email: glx@openttd.org
-role: Windows Expert, General Coding
-nick: glx
----

--- a/_people/matthijs.md
+++ b/_people/matthijs.md
@@ -1,6 +1,0 @@
----
-name: Matthijs Kooijman
-email: matthijs@openttd.org
-role: Pathfinder Expert
-nick: matthijs
----

--- a/_people/michi_cc.md
+++ b/_people/michi_cc.md
@@ -1,6 +1,0 @@
----
-name: Michael Lutz
-email: michi_cc@openttd.org
-role: Path Based Signals (YAPP), Windows x64 Expert
-nick: michi_cc
----

--- a/_people/orudge.md
+++ b/_people/orudge.md
@@ -1,6 +1,0 @@
----
-name: Owen Rudge
-email: orudge@openttd.org
-role: OS/2 port, Forum Host
-nick: orudge
----

--- a/_people/peter1138.md
+++ b/_people/peter1138.md
@@ -1,5 +1,0 @@
----
-name: Peter Nelson
-role: NewGRF, General Coding
-nick: peter1138
----

--- a/_people/planetmaker.md
+++ b/_people/planetmaker.md
@@ -1,6 +1,0 @@
----
-name: Ingo von Borstel
-email: planetmaker@openttd.org
-role: Basesets
-nick: planetmaker
----

--- a/_people/rubidium.md
+++ b/_people/rubidium.md
@@ -1,6 +1,0 @@
----
-name: Remko Bijker
-email: rubidium@openttd.org
-role: General Coding
-nick: Rubidium
----

--- a/_people/smatz.md
+++ b/_people/smatz.md
@@ -1,5 +1,0 @@
----
-name: Zdeněk Sojka
-role: General Coding
-nick: SmatZ
----

--- a/_people/terkhen.md
+++ b/_people/terkhen.md
@@ -1,5 +1,0 @@
----
-name: José Soler
-role: General Coding
-nick: Terkhen
----

--- a/_people/truebrain.md
+++ b/_people/truebrain.md
@@ -1,6 +1,0 @@
----
-name: Patric Stout
-email: truebrain@openttd.org
-role: SysOp
-nick: TrueBrain
----

--- a/_people/yexo.md
+++ b/_people/yexo.md
@@ -1,6 +1,0 @@
----
-name: Thijs Marinussen
-email: yexo@openttd.org
-role: AI Framework
-nick: Yexo
----

--- a/_people/zuu.md
+++ b/_people/zuu.md
@@ -1,6 +1,0 @@
----
-name: Leif Linse
-email: zuu@openttd.org
-role: AI/Game Script, General Coding
-nick: Zuu
----

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -6,45 +6,22 @@ permalink: /contact.html
 ---
 
 <div id="section-full">
+    {% assign contact_sorted = site.contact | where_exp: "contact", "contact.sort_priority >= 0" | sort: "sort_priority" %}
+    {% for contact in contact_sorted %}
     <div class="section-header">
-        <h3>Contact Information</h3>
+        <h3>{{ contact.name }}</h3>
     </div>
     <div class="section-item">
         <div class="content">
-            <p>Individual developers are reachable at the following addresses. Note: these are not meant for your questions about a feature, bug, can't get something to work, or want something implemented. You should direct these questions to the <a href="https://forum.openttd.org/">forums</a> or in our IRC channel.</p>
-            <p>Bug reports can be discussed on IRC or forums, but the best place for it to be addressed is on our <a href="{{ site.baseurl }}/development.html">bug tracker</a>.</p>
-            <p>Do not address support requests or general questions to individual developers. You will not get an answer this way!</p>
+            <p>{{ contact.content }}</p>
             <ul class="section-list">
-                {% assign high_priority_contacts = site.people | where_exp: "person", "person.sort_priority >= 0" | sort: "sort_priority" %}
-                {% assign lower_priority_contacts = site.people | where_exp: "person", "person.sort_priority == nil" %}
-                {% assign people_sorted = high_priority_contacts | concat: lower_priority_contacts %}
-                {% for person in people_sorted %}
-                    <li>
-                        <div class="header">
-                            {{ person.name }}
-                            {% if person.nick %}
-                                ({{ person.nick }})
-                            {% endif %}
-                        </div>
-                            <div class="content">
-                            {% if person.email %}
-                            <span style="display: block;">Email: <a href="mailto:{{ person.email }}">{{ person.email }}</a></span>
-                            {% endif %}
-                            {% if person.role %}
-                                <span style="display: block;">Role: {{ person.role }}</span>
-                            {% endif %}
-                        <div>
-                    </li>
+                {% for location in contact.locations %}
+                <li>
+                    <b>{{ location.name }}</b>: <a href="{{ location.link }}">{{ location.caption }}</a>
+                </li>
                 {% endfor %}
-            </ul>
+           </ul>
         </div>
     </div>
-    <div class="section-header">
-        <h3>IRC</h3>
-    </div>
-    <div class="section-item">
-        <div class="content">
-            <p>For a more immediate form of communication you can join us in the <a href="irc://irc.oftc.net/openttd">#openttd</a> channel on <a href="https://www.oftc.net/">OFTC</a> with your favourite <a href="https://www.irchelp.org">IRC</a> client. You can use the channel for questions, problems, development or general discussion.</p>
-        </div>
-    </div>
+    {% endfor %}
 </div>


### PR DESCRIPTION
It no longer shows email-addresses of Developers, but instead
gives a whole bunch of places people could go to for the contact
they are looking for.

This is mostly triggered by the increased amount of questions
we get at info@, which is not a place you will receive an answer
from.

- [x] Check with Discord if they mind us linking there
- [x] Check with Reddit if they mind us linking there

![image](https://user-images.githubusercontent.com/1663690/109363701-77c43000-788d-11eb-8fdd-a2781b235212.png)

