### PR TITLE
Add: 1.11 Title screen voting announcement

### DIFF
--- a/_posts/2021-03-15-openttd-1-11-titlegame-voting.md
+++ b/_posts/2021-03-15-openttd-1-11-titlegame-voting.md
@@ -1,0 +1,10 @@
+---
+title: Vote for the title screen of OpenTTD 1.11
+author: 2TallTyler
+---
+
+Did you know that the savegame which plays behind the main menu of OpenTTD is created and selected by the community?
+
+As we approach the release of OpenTTD 1.11.0, it's time to select the next title screen. Entries were open for four weeks on [TT-Forums](https://www.tt-forums.net/viewtopic.php?f=29&t=88509) and we received five entries from Erato, Timberwolf, didac, Emperor Jake, and Chrnan6710.
+
+To vote, head over to [GitHub](https://github.com/OpenTTD/title-screen-competition-1.11/discussions/3). You'll need a GitHub account (free). The deadline is Sunday, March 28, 2021, at 23:59:00 UTC.


### PR DESCRIPTION
Voting for the 1.11 title screen will begin later today. Voting will be open for about two weeks, and TrueBrain said a news item is fine with him.