### PR TITLE
Add: Announcement for April 2 livestream

### DIFF
--- a/_posts/2021-03-22-livestream-2-april.md
+++ b/_posts/2021-03-22-livestream-2-april.md
@@ -1,0 +1,8 @@
+---
+title: Developers livestream on April 2nd
+author: 2TallTyler
+---
+
+Come chat with us about OpenTTD! We held our first Twitch livestream late last year (you may have heard rumors of hovercraft shenanigans, [which we deny](https://www.youtube.com/watch?v=ghUEXPdqonI)), and will host another on April 2nd. Tune in at 18:00 UTC on [Twitch](https://www.twitch.tv/openttdlive/about) — here's a handy [countdown and time zone converter](https://a.chronus.eu/19B5298).
+
+Live to chat about NewGRF and OpenTTD development will be 2TallTyler, andythenorth, frosch, and Timberwolf, with TrueBrain behind the scenes to run the stream and ask us your questions posted in the chat. We hope you'll join us!


### PR DESCRIPTION
We're going live on Twitch again! I volunteered to write this post and make an announcement on Reddit. (Who is writing the Discord announcement?)

TrueBrain said the livestream will be at 2000 CEST, which [worldtimebuddy](https://www.worldtimebuddy.com/) says is 18:00 UTC.