### PR TITLE
Fix: Typo in screenshot description

### DIFF
--- a/_screenshots/0.7-Slintfield_Transport_michael_schulze_XX_20090524.md
+++ b/_screenshots/0.7-Slintfield_Transport_michael_schulze_XX_20090524.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Using long and high bridges to cross valeys.
+Using long and high bridges to cross valleys.


### PR DESCRIPTION
Noticed it in the website build in-between 1.11 being released & the news post being deployed :)