### PR TITLE
Add: Announcement for April 9 livestream

### DIFF
--- a/_posts/2021-04-03-livestream-9-april.md
+++ b/_posts/2021-04-03-livestream-9-april.md
@@ -1,0 +1,10 @@
+---
+title: Developers Q&A livestream on April 9th
+author: michi_cc
+---
+
+Come ask us questions about OpenTTD!
+After our fun but disagreeable second Twitch livestream [last week](https://www.youtube.com/watch?v=XXXXXXXXX) and a very successfull release on Steam, we will host a chat Q&A stream on April 9th.
+Tune in at 18:00 UTC on [Twitch](https://www.twitch.tv/openttdlive/about) — here's a handy [countdown and time zone converter](https://a.chronus.eu/19B79F8).
+
+LordAro, Timberwolf, TrueBrain and michi_cc will try but probably fail in answering all your questions you never dared to ask about OpenTTD in chat.

--- a/_posts/2021-04-03-livestream-9-april.md
+++ b/_posts/2021-04-03-livestream-9-april.md
@@ -4,7 +4,7 @@ author: michi_cc
 ---
 
 Come ask us questions about OpenTTD!
-After our fun but disagreeable second Twitch livestream [last week](https://www.youtube.com/watch?v=XXXXXXXXX) and a very successfull release on Steam, we will host a chat Q&A stream on April 9th.
+After our fun but disagreeable second Twitch livestream [yesterday](https://www.youtube.com/watch?v=M96VjKihxNc) and a very successfull release on Steam, we will host a chat Q&A stream on April 9th.
 Tune in at 18:00 UTC on [Twitch](https://www.twitch.tv/openttdlive/about) — here's a handy [countdown and time zone converter](https://a.chronus.eu/19B79F8).
 
 LordAro, Timberwolf, TrueBrain and michi_cc will try but probably fail in answering all your questions you never dared to ask about OpenTTD in chat.

--- a/_posts/2021-04-03-livestream-9-april.md
+++ b/_posts/2021-04-03-livestream-9-april.md
@@ -4,7 +4,7 @@ author: michi_cc
 ---
 
 Come ask us questions about OpenTTD!
-After our fun but disagreeable second Twitch livestream [yesterday](https://www.youtube.com/watch?v=M96VjKihxNc) and a very successfull release on Steam, we will host a chat Q&A stream on April 9th.
+After our fun but disagreeable second Twitch livestream [yesterday](https://www.youtube.com/watch?v=M96VjKihxNc) and a very successful release on Steam, we will host a chat Q&A stream on April 9th.
 Tune in at 18:00 UTC on [Twitch](https://www.twitch.tv/openttdlive/about) — here's a handy [countdown and time zone converter](https://a.chronus.eu/19B79F8).
 
 LordAro, Timberwolf, TrueBrain and michi_cc will try but probably fail in answering all your questions you never dared to ask about OpenTTD in chat.


### PR DESCRIPTION
Announcement for the planned Q&A stream on April 9th.

YouTube link for last livestream needs to be filled in or removed.

Attendance list to be confirmed.