### PR TITLE
Fix: [Actions] prevent multiple deployments at the same time

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,6 +3,8 @@ name: Deployment
 on:
   deployment:
 
+concurrency: ${{ github.event.deployment.environment }}
+
 jobs:
   deploy_to_aws:
     name: Deploy to AWS


### PR DESCRIPTION
GitHub added a cool new feature, that finally removes us humans having to think about this.

Now you can just go nuts with merges and releases etc, GitHub will prevent 2 deployments happening at the same time (which error out on AWS).