### PR TITLE
Add: 1.11.2 release post

### DIFF
--- a/_posts/2021-05-03-openttd-1-11-2.md
+++ b/_posts/2021-05-03-openttd-1-11-2.md
@@ -5,8 +5,8 @@ author: TrueBrain
 
 Today we released our second bugfix release of the 1.11 release series!
 
-We found the cause of several OpenGL related crashes, mostly on Intel GPUs.
-This release should fix most of those issues, meaning more people can enjoy OpenTTD out-of-the-box!
+This release mainly addresses several crashes on startup, mostly caused by our shiny new OpenGL driver.
+More people should now be able to enjoy OpenTTD out-of-the-box!
 
 And as always, we also fixed tons of other small bugs and problems that were reported and found.
 See the changelog for more detail.

--- a/_posts/2021-05-03-openttd-1-11-2.md
+++ b/_posts/2021-05-03-openttd-1-11-2.md
@@ -1,0 +1,16 @@
+---
+title: OpenTTD 1.11.2
+author: TrueBrain
+---
+
+Today we released our second bugfix release of the 1.11 release series!
+
+We found the cause of several OpenGL related crashes, mostly on Intel GPUs.
+This release should fix most of those issues, meaning more people can enjoy OpenTTD out-of-the-box!
+
+And as always, we also fixed tons of other small bugs and problems that were reported and found.
+See the changelog for more detail.
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/latest.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/1.11.2/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Kept it simple, as .. it is just a patch release.

Reddit: just the link: https://www.openttd.org/news/2021/05/03/openttd-1-11-2.html

Discord:
```
Hi @everyone,

OpenTTD 1.11.2 has just been released!

Now users with Intel GPUs should be able to enjoy the game too!
Owh, and also a bunch of bug-fixes while we were at it.

https://www.openttd.org/news/2021/05/03/openttd-1-11-2.html
```
Twitter:
```
OpenTTD 1.11.2 now available on Steam / our website.
More bugfixes! And it now should run fine on Intel GPUs too!
https://www.openttd.org/news/2021/05/03/openttd-1-11-2.html
```
tt-forums, update on 1.11 post:
```
OpenTTD 1.11.2 is now ready for download!
```
Steam: website post, with this image:
![image](https://user-images.githubusercontent.com/1663690/116905892-dfa54700-ac3f-11eb-9a8e-9894e30bde5f.png)
