### PR TITLE
Fix: [Actions] queue publish jobs so they are executed in order

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ on:
     - publish_latest_tag
     - publish_master
 
+concurrency: publish
+
 jobs:
   publish_image:
     name: Publish image


### PR DESCRIPTION
Without this, it is possible that a newer job builds faster and
deploys before the older job, reverting the website to an old
state.