### PR TITLE
Add: [Cloudflare Pages] automation to deploy website to Cloudflare Pages

### DIFF
--- a/.github/workflows/cloudflare-pages-production.yml
+++ b/.github/workflows/cloudflare-pages-production.yml
@@ -1,0 +1,18 @@
+name: Deploy on Cloudflare Pages (Production)
+
+on:
+  repository_dispatch:
+    types:
+    - publish_latest_tag
+
+concurrency: cfp-production
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Trigger deploy hook
+      run: |
+        curl -X POST ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK_PRODUCTION }}

--- a/.github/workflows/cloudflare-pages-staging.yml
+++ b/.github/workflows/cloudflare-pages-staging.yml
@@ -1,0 +1,18 @@
+name: Deploy on Cloudflare Pages (Staging)
+
+on:
+  repository_dispatch:
+    types:
+    - publish_main
+
+concurrency: cfp-staging
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Trigger deploy hook
+      run: |
+        curl -X POST ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK_STAGING }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: New Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  new_release:
+    name: New Release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Get SHA of tag
+      id: tag_sha
+      uses: octokit/request-action@v2.x
+      with:
+        route: GET /repos/{repository}/commits/{tag}?per_page=1
+        repository: ${{ github.repository }}
+        tag: ${{ github.event.release.tag_name }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Copy main branch to production branch
+      uses: octokit/request-action@v2.x
+      with:
+        route: PATCH /repos/{repository}/git/refs/heads/production
+        repository: ${{ github.repository }}
+        sha: ${{ fromJson(steps.tag_sha.outputs.data).sha }}
+        force: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Scripts are very simple:
- On trigger to build main/latest, call Deploy Hook on Cloudflare Pages
- On release, copy "main" to "production"

Cloudflare Pages takes care of the rest.

Not deployed live yet, the "shadow" URLs are:

https://www-test.openttd.org/
https://www-staging-test.openttd.org/