### PR TITLE
Update: minimum macos version

### DIFF
--- a/_data/download-descriptions.yml
+++ b/_data/download-descriptions.yml
@@ -205,9 +205,9 @@ linux-ubuntu-xenial-i386-dbg.deb:
 linux-ubuntu-xenial-i386.deb:
   description: Linux Ubuntu Xenial 16.04 (i386, 32 bit)
 macos-universal.dmg:
-  description: macOS 10.9+ / 11 (Big Sur) (Intel / Apple Silicon) (disk image)
+  description: macOS 10.14+ / 11 (Big Sur) (Intel / Apple Silicon) (disk image)
 macos-universal.zip:
-  description: macOS 10.9+ / 11 (Big Sur) (Intel / Apple Silicon) (zip archive)
+  description: macOS 10.14+ / 11 (Big Sur) (Intel / Apple Silicon) (zip archive)
 macosx-i686.zip:
   description: Mac OS X 10.4-10.5 (Intel build)
 macosx-arm64.dmg:


### PR DESCRIPTION
Since merge of https://github.com/OpenTTD/OpenTTD/pull/9391, the minimum macos version required to run OpenTTD (nightlies or 12.0+) is 10.14.

There's a limitation with this change, previous versions are compatible with 10.9+, but it's now hidden.