### PR TITLE
Add: devcontainer to make development easier

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+ARG VARIANT=2-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-${VARIANT}
+
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# Install all Gems, as installing takes a long time.
+COPY Gemfile \
+     Gemfile.lock \
+     /tmp/gem-tmp/
+RUN gem update && bundle install --gemfile=/tmp/gem-tmp/Gemfile && rm -rf /tmp/gem-tmp
+
+# Customized first-run-notice to give clues how to work with this devcontainer.
+COPY .devcontainer/first-run-notice.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
+
+# There is not a way to change the location of the default Python interpreter.
+# So instead, we symlink the right path to the default one GitHub Codespaces expects.
+RUN ln -s /usr/local/python/bin/python /usr/local/bin/python

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -1,4 +1,16 @@
+# This is a multi-stage Docker build
+
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.8-bullseye as python
+
+# Do nothing; we just use it to get data from this image.
+
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-2-bullseye
+
+# Copy in the important parts of the Python image.
+COPY --from=python /usr/local/ /usr/local/
+# Cheat a little bit by adding the /usr/local/lib to the library searchpath.
+# The original image uses /opt/ for this, but this requires a lot more work.
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/python.conf && ldconfig
 
 # Install all Gems, as installing takes a long time.
 COPY Gemfile \
@@ -8,7 +20,3 @@ RUN gem update && bundle install --gemfile=/tmp/gem-tmp/Gemfile && rm -rf /tmp/g
 
 # Customized first-run-notice to give clues how to work with this devcontainer.
 COPY .devcontainer/first-run-notice.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
-
-# There is not a way to change the location of the default Python interpreter.
-# So instead, we symlink the right path to the default one GitHub Codespaces expects.
-RUN ln -s /usr/local/python/bin/python /usr/local/bin/python

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -1,8 +1,4 @@
-ARG VARIANT=2-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-${VARIANT}
-
-ARG NODE_VERSION="none"
-RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-2-bullseye
 
 # Install all Gems, as installing takes a long time.
 COPY Gemfile \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+{
+	"name": "Ruby",
+	"runArgs": ["--init"],
+	"build": {
+		"context": "..",
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "2-bullseye",
+			"NODE_VERSION": "lts/*"
+		}
+	},
+
+	"settings": {
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"files.trimTrailingWhitespace": true
+	},
+
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance"
+	],
+
+	"remoteEnv": {
+		"JEKYLL_ENV": "production"
+	},
+
+	"postStartCommand": ".devcontainer/post-start.sh",
+
+	"remoteUser": "vscode",
+	"features": {
+		"python": "3.8"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,12 @@
 {
 	"name": "Ruby",
 	"runArgs": ["--init"],
-	"build": {
-		"context": "..",
-		"dockerfile": "Dockerfile",
-		"args": {
-			"VARIANT": "2-bullseye",
-			"NODE_VERSION": "lts/*"
-		}
-	},
+	"image": "ghcr.io/truebrain/openttd-website:devcontainer",
+	// Disable "image" and enable "build" if you want to rebuild the devcontainer locally.
+	// "build": {
+	// 	"context": "..",
+	// 	"dockerfile": "base.Dockerfile",
+	// },
 
 	"settings": {
 		"python.linting.enabled": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,4 @@
 	"postStartCommand": ".devcontainer/post-start.sh",
 
 	"remoteUser": "vscode",
-	"features": {
-		"python": "3.8"
-	}
 }

--- a/.devcontainer/first-run-notice.txt
+++ b/.devcontainer/first-run-notice.txt
@@ -1,0 +1,3 @@
+👋 Welcome to OpenTTD's website devcontainer!
+
+📝 Press F1 -> "Tasks: Run Tasks" -> "Start server" to start Jekyll. After that, edit away!

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -ex
+
+# Install latest Ruby requirements (most are baked in the devcontainer, but check for updates)
+bundle install
+bundle clean --force
+
+# Install latest Python requirements
+pip install -r requirements.txt
+
+# Fetch the latest downloads
+python -m fetch_downloads
+
+# Ensure the git submodule is initialized
+git submodule update --init

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,9 @@
 __pycache__/
 *.pyc
-/.env
 /.git/**
 /.jekyll-cache/
 /.jekyll-metadata/
 /.sass-cache/
+/.venv/
 /_downloads/**
 /_site/

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,42 @@
+name: Pre-build devcontainer
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+    paths:
+      - Gemfile
+      - Gemfile.lock
+      - '.devcontainer/**'
+      - '.vscode/**'
+
+concurrency: devcontainer
+
+jobs:
+  publish_image:
+    name: Publish image
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set variables
+      id: vars
+      run: |
+        REPOSITORY_LC=$(echo "${{ github.repository }}" | tr [A-Z] [a-z])
+        echo "::set-output name=name::${REPOSITORY_LC}"
+
+    - name: Build
+      run: |
+        docker build -t ghcr.io/${{ steps.vars.outputs.name }}:devcontainer -f .devcontainer/base.Dockerfile .
+
+    - name: Publish
+      uses: openttd/actions/docker-publish@v2
+      with:
+        registry-username: ${{ secrets.GHCR_USERNAME }}
+        registry-password: ${{ secrets.GHCR_PASSWORD }}
+        registry: ghcr.io
+        name: ${{ steps.vars.outputs.name }}
+        tag: devcontainer

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 __pycache__/
 *.pyc
-/.env
 /.jekyll-cache/
 /.jekyll-metadata/
 /.sass-cache/
+/.venv/
 /_downloads/**
 /_site/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Start server",
+            "type": "shell",
+            "command": "jekyll serve",
+            "problemMatcher": [],
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            }
+        },
+        {
+            "label": "Update downloads",
+            "type": "shell",
+            "command": "python -m fetch_downloads",
+            "problemMatcher": [],
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            }
+        }
+    ]
+}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,4 +70,4 @@ DEPENDENCIES
   jekyll-paginate-v2 (~> 3.0.0)
 
 BUNDLED WITH
-   2.2.24
+   2.2.30

--- a/README.md
+++ b/README.md
@@ -19,16 +19,25 @@ This is a [Jekyll](https://jekyllrb.com/) website, and is served by nginx as a s
 
 ## Development
 
-### Populating _downloads
+### Running via devcontainer / VSCode Remote Containers / GitHub Codespaces
+
+If you open up this repository with VSCode Remote Containers or GitHub Codespaces, it will automatically set up the development environment for you.
+You are immediately ready for development.
+
+There are two predefined tasks for you (you can access these via F1 -> "Run Tasks"):
+- "Update downloads": fetches the latest downloads available. This is also done on start-up of the devcontainer.
+- "Start server": starts the webserver. A popup will show to open the browser to view the website.
+
+### Populating _downloads (only for any of the below methods of development)
 
 By default `_downloads` is empty, so when building the website locally there is no latest stable/nightly.
 This can be resolved by running `fetch_downloads`.
 This script will download the latest available binaries, and populate `_downloads`.
 
 ```bash
-python3 -m venv .env
-.env/bin/pip install -r requirements.txt
-.env/bin/python -m fetch_downloads
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+.venv/bin/python -m fetch_downloads
 ```
 
 ### Running a local server

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ plugins:
 
 exclude:
   - Dockerfile
-  - fetch-downloads.py
+  - fetch_downloads
   - nginx.default.conf
   - requirements.base
   - requirements.txt


### PR DESCRIPTION
So this requires a bit of story.
tldr; this is PR is to test the waters, to see if we like this approach, and if the benefits of "anyone can jump in" outweigh the "but there are IDE-specific things in the repo".

But if you want to pitch in, I really urge you to read what I write below :)

For a while now I notice that there are people who have the best intentions to help out with things like our website, but also bananas-server, master-server-web, game-coordinator, etc. But mainly they get stuck in how to setup the development environment.

It is not that the environments themselves are complex, but each repository has its own required setup to work. Take for example game-coordinator, it requires a redis to run, but it is also composed of three applications: coordinator, stun and turn. These all three needs a bit of configuration. Nothing that is not documented, but to "just jump in and develop" is not the case.

I even notice that myself. This week frosch mentioned that a bug in master-server is most likely easily solved by changing a `set` into a `set(nx=True)`. But to test this, it takes me time to setup the right environment and validate that. As it is a really minor thing, I postpone this. (read: I cannot just jump in)

For BaNaNaS related repository, we have had several people just give up because they couldn't follow the README. Now we can argue that the README is not clear and should be updated, but really .. it contains everything you need. It is just "a lot" if you never worked with it. In the BaNaNaS case specifically, you kinda want some dummy files to play around with .. and that is just difficult to get done on a moments notice.

So, I have been wondering what ["devcontainers"](https://code.visualstudio.com/docs/remote/create-dev-container) is all about. GitHub claims it solves all those problems, so I gave it a spin with this repository (this repository is not the most complicated we have, but also not the easiest). Basically devcontainers can be used in two ways:

- Via VSCode Remote Containers
- Via GitHub Codespaces

The idea behind devcontainers is that it contains everything you need to get a working setup. Including databases, storages, ... Additionally, it helps you as much as possible to just "jump in". But, one drawback, it is strongly biased towards the use of VSCode. It is slowly being made a bit more broad, but I have no illusions it will always remain VSCode-ish. For example, only [since recent](https://github.blog/changelog/2021-10-27-new-codespaces-features-launching-at-universe-2021/) it is easier to ssh into Codespaces to use `emacs` or `vim` to develop with. And I couldn't find any other editor that implements devcontainers (I love to be proven wrong here!).
More details about devcontainers, and what they are about, can be found [here](https://code.visualstudio.com/docs/remote/containers).

Either way, this is PR is to test the waters, to see if we like this approach, and if the benefits of "anyone can jump in" outweigh the "but there are IDE-specific things in the repo".

If you are signed up for [GitHub Codespaces](https://github.com/codespaces), you can press the green "Code" button on https://github.com/TrueBrain/OpenTTD-website and hit "New codespace".

![image](https://user-images.githubusercontent.com/1663690/139501234-a70701b3-abbf-4777-8520-19b3a6d40dff.png)

Within a minute or-so you are in VSCode ready to edit the website. Via F1 -> Run Tasks -> Start server, you can start the server. A popup will ask you to open a tab to see the website. And that makes writing blog-posts etc a lot easier, as you can see how the layout will be. But it also allows for easier CSS changes, validating of PRs, etc etc. And .. you can do it from anywhere you like ;)
If you don't want to use Codespaces, you can use VSCode Remote Containers extension. After installing the extension you can go to F1 -> Remote-Containers: Clone Repository in Container Volume. Fill in https://github.com/TrueBrain/OpenTTD-website and off you go. A few minutes later (assuming you have Docker installed) you can edit the website exactly as described above.

(and before anyone asks, after merging these PR, the above URLs of course changes into this repository; but I pushed it to my fork so you can try it out!)

If this idea works, and we like this approach, I want to try to do bananas-server next. This also requires a working OpenTTD game to communicate with the bananas-server for testing (next to checking out some dummy BaNaNaS files etc). I am considering using Emscripten for this, so it works from your browser. This hopefully makes it really trivial to try things out with Codespaces.
For the VSCode Remote Containers route, you can just start OpenTTD with `OTTD_CONTENT_CS="localhost"`, to test against.

Either way .. if it is up to me, this is the first of many of very similar PRs to make our development environments a lot easier for anyone to work with .. to just "jump in and develop". Hopefully that attracts more developers to help out.

Let me know what you think, please try it out (make sure to signup for Codespaces ;)), and if you have any improvements / suggestions, I am all ears!