### PR TITLE
Fix: ruby-bundler is no longer installed indirectly, add it explicitly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apk --no-cache add \
         libstdc++ \
         ruby \
         ruby-bigdecimal \
+        ruby-bundler \
         ruby-dev \
         ruby-etc \
         ruby-json \


### PR DESCRIPTION
Building the docker container fails due to missing "bundle".

Looks like alpine cleaned up some dependencies, so it was no longer installed via other packages.
