### PR TITLE
Add: 12.2 release announcement

### DIFF
--- a/_posts/2022-04-02-openttd-12-2.md
+++ b/_posts/2022-04-02-openttd-12-2.md
@@ -1,0 +1,15 @@
+---
+title: OpenTTD 12.2
+author: michi_cc
+---
+
+We tried to release OpenTTD 13 on April 1st, but supply chain issues are affecting new feature production and forced us to delay the release.
+
+To compensate, we swept the factory floor for bits and pieces that where left around and could be repurposed.
+We found enough to be able to produce a 12.2 maintenance release for you.
+
+More details in the changelog below.
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/latest.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/12.2/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
For twitter:
```
Late April Fools! 12.2 is now available on GOG / Steam / our website!
https://www.openttd.org/news/2022/04/02/openttd-12-2.html
```

Reddit:
```
Late April Fools! 12.2 is now released!

https://www.openttd.org/news/2022/04/02/openttd-12-2.html
```

Steam / Discord / tt-forums:
Same as the post