### PR TITLE
Add: 13.0-beta1 announcement

### DIFF
--- a/_posts/2022-10-31-openttd-13-0-beta1.md
+++ b/_posts/2022-10-31-openttd-13-0-beta1.md
@@ -6,7 +6,7 @@ author: michi_cc
 Are you spooked?
 We are too with this spooky release date, even if nothing in OpenTTD itself is spooky.
 
-Luckily, I can offer your the first testing release of the 13.X release series.
+Luckily, I can offer you the first testing release of the 13.X release series.
 We collected whatever we could find on the cutting room floor to get you a Halloween release.
 
 Some of the higlights of this release include:

--- a/_posts/2022-10-31-openttd-13-0-beta1.md
+++ b/_posts/2022-10-31-openttd-13-0-beta1.md
@@ -1,0 +1,26 @@
+---
+title: OpenTTD 13.0-beta1
+author: michi_cc
+---
+
+Are you spooked?
+We are too with this spooky release date, even if nothing in OpenTTD itself is spooky.
+
+Luckily, I can offer your the first testing release of the 13.X release series.
+We collected whatever we could find on the cutting room floor to get you a Halloween release.
+
+Some of the higlights of this release include:
+* Build NewGRF objects over an era with click-and-drag.
+* Wider rivers on map geenration.
+* Improved handling of HiDPI and mixed-DPI screens.
+* Some more GUI improvements like a cleaned up finance window.
+* Many bug-fixes (over 50 of them), tweaks, changes, and other additions.
+
+(As ever, see the changelog for further details).
+
+The usual titlegame competition has been [announced on the forums](https://www.tt-forums.net/viewtopic.php?t=90357).
+See the page for the exact competition rules if you are interesed.
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/13.0-beta1/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)

--- a/_posts/2022-10-31-openttd-13-0-beta1.md
+++ b/_posts/2022-10-31-openttd-13-0-beta1.md
@@ -11,7 +11,7 @@ We collected whatever we could find on the cutting room floor to get you a Hallo
 
 Some of the higlights of this release include:
 * Build NewGRF objects over an era with click-and-drag.
-* Wider rivers on map geenration.
+* Wider rivers on map generation.
 * Improved handling of HiDPI and mixed-DPI screens.
 * Some more GUI improvements like a cleaned up finance window.
 * Many bug-fixes (over 50 of them), tweaks, changes, and other additions.


### PR DESCRIPTION
Preview: https://release-13-beta1.openttd-website.pages.dev

Reddit / Discord / tt-forums:
```
Halloween is around and we want to clean out the cutting room floor.
I can offer you the first testing release of the 13.X release series containing the results.

We found some nice improvements like building objects by dragging or better rivers on map generation.
The UI got some polish, too, both by having some improved windows in-game and a by a better handling of HiDPI contexts.

Go check it out today and help us break the game!

https://www.openttd.org/news/2022/10/31/openttd-13-0-beta1.html
```

For twitter:
```
OpenTTD 13.0-beta1 now available on Steam / our website.
Drag objects all over the place and help us break the game.
https://www.openttd.org/news/2022/10/31/openttd-13-0-beta1.html
```

Steam:
Insert nice image here.