### PR TITLE
Add: 13-beta2 announcement

### DIFF
--- a/_posts/2022-11-27-openttd-13-0-beta2.md
+++ b/_posts/2022-11-27-openttd-13-0-beta2.md
@@ -1,0 +1,27 @@
+---
+title: OpenTTD 13.0-beta2
+author: 2TallTyler
+---
+
+Multiple beta releases often indicate lots of bugs to be fixed, but in this case we got carried away adding features and thought more testing was needed.
+
+New features since beta1 include:
+* Variable interface scaling at whatever size you want (not just 2x and 4x), with optional chunky bevels for that retro feel.
+* Multi-track level crossings to keep road vehicles from stopping in the middle of the crossing.
+* A new Generate World menu which now includes NewGRF, AI, and Game Script configuration menus.
+* Cargo filters for vehicle lists (such as at stations) to allow better visualization of traffic.
+* Optional cargo names above vehicles in vehicle lists, to show at a glance what they carry.
+* The ability to clone or share orders with vehicles grouped by shared orders.
+* An improved local authority action window which now shows you actions you can't afford, instead of hiding them.
+
+In addition, some new tools are available to AI and Game Script authors:
+* Scriptable league tables which can replace the default scoring system
+* AI and Game Scripts can now be modified in Scenario Editor for existing scenarios (although not savegames)
+
+(As ever, see the changelog for further details).
+
+If you've been working on an entry for the [title game competition](https://www.tt-forums.net/viewtopic.php?t=90357), it's time to finish and submit it!
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/13.0-beta2/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Reddit / Discord/ TT-Forums:

```
Multiple beta releases often indicate lots of bugs to be fixed, but in this case we got carried away adding features and thought more testing was needed.

The big new feature is variable interface scaling, not just at 2x and 4x, with chunky bevels for that retro feel! We've also made multi-track level crossings safer, changed the World Generation menu to make NewGRF, AI/ and Game Script configuration more convenient, and made several enhancements to vehicle lists.

Go check it out today and help us break the game!

https://www.openttd.org/news/2022/11/27/openttd-13-0-beta2.html
```

For Twitter (if it's still around 😛 ):
```
OpenTTD 13.0-beta1 now available on Steam / our website.
Resize the game interface to your liking and check out the new chunky bevels!
https://www.openttd.org/news/2022/11/27/openttd-13-0-beta2.html
```

Steam image:
![13 0-beta2 release](https://user-images.githubusercontent.com/55058389/204144099-8a0e51f2-0331-46ae-8ed7-021b8a9df502.png)
.xcf: [13.0-beta2 release.zip](https://github.com/OpenTTD/website/files/10098636/13.0-beta2.release.zip)

