### PR TITLE
Add: 13.0-RC1 announcement

### DIFF
--- a/_posts/2023-01-01-openttd-13-0-rc1.md
+++ b/_posts/2023-01-01-openttd-13-0-rc1.md
@@ -1,0 +1,16 @@
+---
+title: OpenTTD 13.0-RC1
+author: michi_cc
+---
+
+Rejoice, for we are now in feature freeze for the 13.0 release series just in time for a new year!
+
+Some last minute features and fixed made it into the new year.
+Especially notable are the new vehicle variants feature for NewGRFs and automatic flipping support for shorten-than-default NewGRF-defined vehicles.
+On the fixing side, focus was on polishing the new fractional GUI zoom and some other minor bits and pieces.
+
+Testing is more important than ever, so please keep it up, and report any issues as normal!
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/13.0-RC1/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Preview: https://release-13-rc1.openttd-website.pages.dev

Reddit / Discord / tt-forums:
```
The next year has come and with it the feature freeze for the 13.X release series.

The new 13.0-RC1 testing release brings various fixes and a few new features like NewGRF vehicle variants.

Go check it out today and help us find any last minute bugs!
Available on Steam / GOG / our website as usual.

https://www.openttd.org/news/2023/01/01/openttd-13-0-RC1.html
```

For twitter:
```
New year, new OpenTTD, one step closer to 13.0.
OpenTTD 13.0-RC1 now available on Steam / GOG / our website.

https://www.openttd.org/news/2023/01/01/openttd-13-0-RC1.html
```

Steam:
Insert nice image here.