### PR TITLE
Add: 13.0-RC2 announcement

### DIFF
--- a/_posts/2023-01-28-openttd-13-0-rc2.md
+++ b/_posts/2023-01-28-openttd-13-0-rc2.md
@@ -1,5 +1,5 @@
 ---
-title: OpenTTD 13.0-RC1
+title: OpenTTD 13.0-RC2
 author: michi_cc
 ---
 

--- a/_posts/2023-01-28-openttd-13-0-rc2.md
+++ b/_posts/2023-01-28-openttd-13-0-rc2.md
@@ -1,0 +1,19 @@
+---
+title: OpenTTD 13.0-RC1
+author: michi_cc
+---
+
+OpenTTD 13.0-RC2 is now available, which fixes a bunch of issues found during RC1 playtesting.
+
+Most fixes are related to AI/GS scripting, the recent GUI zoom improvements and the engine variant support.
+(As ever, see the changelog for further details).
+
+With only a short time left before release, please take the effort to test our latest Release Candidate, to find any issues that are still left!
+Any issues can be reported in the usual [place](https://github.com/OpenTTD/OpenTTD/issues).
+
+Additionally, if you are a translator, please see if [your language has any missing translations](https://translator.openttd.org/project/openttd-master).
+We greatly appreciate your contribution!
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/13.0-RC2/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Preview: https://release-13-rc2.openttd-website.pages.dev

Reddit / Discord / tt-forums:
```
We found some bugs in the 13.0-RC1 testing release that need cleaning up.

The new 13.0-RC2 testing release should fix these and bring us into the home stretch for a final release.
Go check it out today and help us find any last minute bugs we don't know about yet!

If you are a translator, we'd appreciate your help for a translation check before the final release.

https://www.openttd.org/news/2023/01/28/openttd-13-0-rc2.html
```

For twitter:
```
OpenTTD 13.0-RC2 now available on Steam / GOG / our website.
Last minute fixes before a full release.
https://www.openttd.org/news/2023/01/28/openttd-13-0-rc2.html
```