### PR TITLE
Add: 13.0 release announcement

### DIFF
--- a/_posts/2023-02-05-openttd-13-0.md
+++ b/_posts/2023-02-05-openttd-13-0.md
@@ -3,9 +3,9 @@ title: OpenTTD 13.0
 author: michi_cc
 ---
 
-Breaking news: OpenTTD 13.0 is finally available!
+Breaking news: OpenTTD 13.0 is now available! Depending on your perspective, we're either two months early for our usual April 1st release, or a bit tardy for the Christmas 2022 release we intended.
 
-This version brings numerous additions to the game, both on the UI side and on the gameplay side.
+We think the wait has been worth it. This is one of the largest releases we've done in several years, with numerous features and improvements covering the user interface, gameplay features, and modding extensions for NewGRF and Game Script creators.
 
 Some of the highlights are:
 * Variable interface scaling at whatever size you want (not just 2x and 4x), with optional chunky bevels for that retro feel. This includes better automatic scaling when using HiDPI or mixed DPI setups.

--- a/_posts/2023-02-05-openttd-13-0.md
+++ b/_posts/2023-02-05-openttd-13-0.md
@@ -1,0 +1,28 @@
+---
+title: OpenTTD 13.0
+author: michi_cc
+---
+
+Breaking news: OpenTTD 13.0 is finally available!
+
+This version brings numerous additions to the game, both on the UI side and on the gameplay side.
+
+Some of the highlights are:
+* Variable interface scaling at whatever size you want (not just 2x and 4x), with optional chunky bevels for that retro feel. This includes better automatic scaling when using HiDPI or mixed DPI setups.
+* Direct access to NewGRF/AI/GS settings from the new game window.
+* Various small tweaks and improvements to several windows.
+* NewGRFs can now provide engine variants that are shown hierarchically in the purchase list.
+* Multi-track level crossings to keep road vehicles from stopping in the middle of the crossing.
+* Custom league tables for GameScripts.
+* More natural river generation during mapgen.
+* And much more, which can be seen in the changelog or the previous release announcements!
+
+Additional to features and improvements, OpenTTD 13.0 comes with lots of bug fixes for a variety of issues.
+
+Compared to the previous RC2 testing release, there were only three minor bug fixes.
+(As ever, see the changelog for further details).
+
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/latest.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/13.0/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)

--- a/_posts/2023-02-05-openttd-13-0.md
+++ b/_posts/2023-02-05-openttd-13-0.md
@@ -14,7 +14,7 @@ Some of the highlights are:
 * NewGRFs can now provide engine variants that are shown hierarchically in the purchase list.
 * Multi-track level crossings to keep road vehicles from stopping in the middle of the crossing.
 * Custom league tables for GameScripts.
-* More natural river generation during mapgen.
+* More natural rivers which get wider as they flow downstream.
 * And much more, which can be seen in the changelog or the previous release announcements!
 
 Additional to features and improvements, OpenTTD 13.0 comes with lots of bug fixes for a variety of issues.

--- a/_posts/2023-02-05-openttd-13-0.md
+++ b/_posts/2023-02-05-openttd-13-0.md
@@ -17,10 +17,7 @@ Some of the highlights are:
 * More natural rivers which get wider as they flow downstream.
 * And much more, which can be seen in the changelog or the previous release announcements!
 
-Additional to features and improvements, OpenTTD 13.0 comes with lots of bug fixes for a variety of issues.
-
-Compared to the previous RC2 testing release, there were only three minor bug fixes.
-(As ever, see the changelog for further details).
+In addition to these features and improvements, we've fixed lots of bugs. (If you played with the RC2 testing release, most were fixed before then. See the changelog for full details.)
 
 
 * [Download](https://www.openttd.org/downloads/openttd-releases/latest.html)


### PR DESCRIPTION
Preview: https://release-13-0.openttd-website.pages.dev

Reddit / Discord / tt-forums:
```
Breaking news: OpenTTD 13.0 is finally available! Depending on your perspective, we’re either two months early for our usual April 1st release, or a bit tardy for the Christmas 2022 release we intended.

This version brings numerous additions to the game, both on the UI side and on the gameplay side.
Highlights include fractional interface scaling, NewGRF engine variants, multi-track level crossings and various UI improvements.

For the full story, see the release announcement: https://www.openttd.org/news/2023/02/05/openttd-13-0.html
```

For twitter:
```
Breaking news: OpenTTD 13.0 now available on Steam / GOG / our website.
Get all the new features now!
https://www.openttd.org/news/2023/02/05/openttd-13-0.html
```