### PR TITLE
Add: 13.1 release announcement

### DIFF
--- a/_posts/2022-04-10-openttd-13-1.md
+++ b/_posts/2022-04-10-openttd-13-1.md
@@ -1,0 +1,18 @@
+---
+title: OpenTTD 13.1
+author: 2TallTyler
+---
+
+OpenTTD 13.0 has been out for two months and we've found some bugs to fix.
+
+Most notably, we've fixed two kinds of crashes:
+* Road vehicles inside multi-track level crossings no longer crash into the side of trains.
+* The game no longer crashes when a spectator in a network game tries to interact with a town's local authority.
+
+For NewGRF authors using the new engine variant feature introduced in 13.0, we've added a callback to select how the engine's name is displayed in the buy menu.
+
+As always, there are plenty of other bugfixes, which you can find in the changelog.
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/13.1/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Reddit/Discord/TT-Forums:
```
OpenTTD 13.0 has been out for two months and we've found some bugs to fix in 13.1! Most notably, we've fixed two kinds of crashes:
* Road vehicles inside multi-track level crossings no longer crash into the side of trains.
* The game no longer crashes when a spectator in a network game tries to interact with a town's local authority.

For NewGRF authors using the new engine variant feature, we've added a callback to select how the engine's name is displayed in the buy menu.

Go check it out and try not to crash!
https://www.openttd.org/news/2023/04/10/openttd-13-1.html
```

Twitter:
```
OpenTTD 13.1 now available on Steam / our website.
Road vehicles no longer crash into the side of trains!
https://www.openttd.org/news/2023/04/10/openttd-13-1.html
```

Steam:

![News - 13 1 release](https://user-images.githubusercontent.com/55058389/230972827-fefaae70-8988-4d74-86ee-99975afc7f66.png)

[News - 13.1 release.zip](https://github.com/OpenTTD/website/files/11193101/News.-.13.1.release.zip)