### PR TITLE
Fix: 13.1 was released in 2023, not 2022

### DIFF
--- a/_posts/2023-04-10-openttd-13-1.md
+++ b/_posts/2023-04-10-openttd-13-1.md
@@ -13,6 +13,6 @@ For NewGRF authors using the new engine variant feature introduced in 13.0, we'v
 
 As always, there are plenty of other bugfixes, which you can find in the changelog.
 
-* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Download](https://www.openttd.org/downloads/openttd-releases/latest)
 * [Changelog](https://cdn.openttd.org/openttd-releases/13.1/changelog.txt)
 * [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Renamed the file to the proper year.

Also fixed the download link, which was not correct for a non-beta release.