### PR TITLE
Add: update policies and blog about automated opt-in survey

### DIFF
--- a/_posts/2023-05-14-policy-and-survey.md
+++ b/_posts/2023-05-14-policy-and-survey.md
@@ -1,0 +1,42 @@
+---
+title: Policy update and automated opt-in survey
+author: TrueBrain
+---
+
+While working on an automated opt-in survey (about which I write in a bit), it was noticed that our privacy policy and cookie policy is rather out-of-date.
+
+Mostly, we used to store a lot more personal information when you created an account, like email addresses, passwords, etc.
+As we now use GitHub to handle all that, we can slim down our privacy policy, as we store very little personal information.
+
+For the cookie policy, for years now we only use cookies for the authenticated part of our websites and nothing else.
+
+OpenTTD's privacy policy has always been: we want to know as little personal information about you as possible.
+And although these changes were rolled out years ago, the policies did not reflect that yet.
+They do now!
+
+In short: we removed statements from the policy about information we track, as we haven't done that for years now.
+
+So, what about this automated opt-in survey you are talking about?
+
+<!-- more -->
+
+There are many ways to play OpenTTD.
+There are tons of settings; you can also load extensions, from AIs to NewGRFs.
+They all modify how the game plays.
+
+From a developer perspective, we don't actually know which settings are heavily used, and which are never used.
+As such, we often find ourselves in a discussion about whether something is actually useful.
+The people we talk most about, are not our average user; as it goes, the most vocal people are not the commoner, but more likely the niche.
+And although we like to promote as many play-styles as possible, it is easy to focus on those vocal people, instead of the 90%.
+
+From an AI / NewGRF perspective, we don't actually know how many people play a game with an extension.
+As such, it is difficult to judge which extension is actually "popular", and which extension is never really used.
+This means it is tricky on BaNaNaS to suggest any content.
+
+For both cases we are designing an opt-in automated survey.
+It is designed to be privacy friendly, and to be as transparent as possible.
+
+More information about this survey can be found [here](https://survey.openttd.org).
+And once we released our next version (14.0), it will also contain the results of the survey.
+
+If you have any concerns or questions about this, please [join the discussion](https://github.com/OpenTTD/OpenTTD/discussions/10632).

--- a/pages/policy.html
+++ b/pages/policy.html
@@ -14,17 +14,11 @@ permalink: /policy.html
             <h3>Personal Information Collection</h3>
             <p>OpenTTD may collect and use the following kinds of personal information:</p>
             <ul>
-                <li>information that you provide for the purpose of registering with the website (including name and e-mail address);</li>
+                <li>information that you provide for the purpose of registering with the website (GitHub username and user identifier);</li>
                 <li>any other information that you send to OpenTTD.</li>
             </ul>
             <h3>Using Personal Information</h3>
-            <p>OpenTTD may use your personal information to:</p>
-            <ul>
-                <li>administer this website;</li>
-                <li>personalise the website for you;</li>
-                <li>enable your access to and use of the website services;</li>
-                <li>send you notifications</li>
-            </ul>
+            <p>OpenTTD may use your personal information to enable your access to and use of the website services.</p>
             <p>In addition to the disclosures reasonably necessary for the purposes identified elsewhere above, OpenTTD may disclose your personal information to the extent that it is required to do so by law, in connection with any legal proceedings or prospective legal proceedings, and in order to establish, exercise or defend its legal rights.</p>
             <h3>Security of your Data</h3>
             <p>OpenTTD will take reasonable technical and organisational precautions to prevent the loss, misuse or alteration of your personal information.</p>
@@ -51,22 +45,32 @@ permalink: /policy.html
     <div class="section-item">
         <div class="content">
             <h3>About Cookies</h3>
-            <p>Cookies are information packets sent by web servers to web browsers, and stored by the web browsers.</p>
-            <p>The information is then sent back to the server each time the browser requests a page from the server.  This enables web servers to identify and track web browsers.</p>
-            <p>There are two main kinds of cookies: session cookies and persistent cookies.  Session cookies are deleted from your computer when you close your browser, whereas persistent cookies remain stored on your computer until deleted, or until they reach their expiry date.</p>
+            <p>
+                Cookies are small pieces of data stored in text files that are saved on your computer or other devices when websites are loaded in a browser.
+                They are widely used to remember you and your preferences, either for a single visit (through a "session cookie") or for multiple repeat visits (using a "persistent cookie").
+            </p>
+            <p>
+                Session cookies are temporary cookies that are used during the course of your visit to the Website, and they expire when you close the web browser.
+            </p>
+            <p>
+                Persistent cookies are used to remember your preferences within our Website and remain on your desktop or mobile device even after you close your browser or restart your computer.
+                They ensure a consistent and efficient experience for you while visiting the Website and Services.
+            </p>
+            <p>
+                <small>(this text is based on an original template created by websitepolicies.com)</small>
+            </p>
+
             <h3>Cookies on our Website</h3>
-            <p>OpenTTD uses the following cookies on this website, for the following purposes:</p>
-            <ul>
-                <li>Keeping track of customisation wishes of the user on the different websites.</li>
-                <li>Allowing automatic login at different websites.</li>
-            </ul>
-            <h3>Refusing Cookies</h3>
-            <p>Most browsers allow you to refuse to accept cookies.</p>
-            <p>In Internet Explorer, you can refuse all cookies by clicking "Tools", "Internet Options", "Privacy", and selecting 'Block all cookies" using the sliding selector.</p>
-            <p>In Firefox, you can adjust your cookies settings by clicking "Tools", "Options" and "Privacy".</p>
-            <p>Blocking cookies will have a negative impact upon the usability of some websites.</p>
-            <h3>This Cookies Policy</h3>
-            <p>This cookies policy is based on an original template created by <a href="http://template-contracts.co.uk/">template-contracts.co.uk</a> and distributed by <a href="http://freenetlaw.com/">freenetlaw.com</a>.</p>
+            <p>
+                OpenTTD only uses session cookies, and only for the authenticated parts of some of our services (like our wiki, BaNaNaS, etc), so called "necessary cookies".
+                These cookies are only set when you login to those services, and only restrict access to the authenticated part of those services.
+            </p>
+            <p>
+                The name of the cookie always starts with the name of the service (like "wiki" or "bananas") followed by "_sid".
+            </p>
+            <p>
+                OpenTTD does not make use of any functional or any third party cookies.
+            </p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Together with https://github.com/OpenTTD/survey-web/pull/1, I like to publish this blog + policy update.

Basically, the policy was written in a time we had to deal with useraccounts and emails etc etc. It is scary how little information we process these days, and we might as well write that in our policy.

It does require the above mentioned PR to be merged first, as https://survey.openttd.org is an empty page now :)