### PR TITLE
Change: make even short pages take the whole viewport height

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -9,6 +9,9 @@ html {
 }
 body {
 	margin: auto auto;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 select {
 	color: black;
@@ -163,6 +166,7 @@ main {
 	padding: 7px;
 	border-radius: 5px;
 	box-shadow: 0 0 3px 3px rgba(0, 0, 0, 0.11);
+	flex: 1;
 }
 body > footer {
 	background-color: white;


### PR DESCRIPTION
Making the body being a flexbox makes it possible to enlarge the element `main` to the complete viewport height (except the heights for `header`, `nav` and `footer`). This is only an issue on pages with very little content. Longer pages, that stretches the content over the whole viewport by itself, are not affected.

Screenshot 1 shows the donation page, scaled to 67% without the flexbox.

![Screenshot 1, page takes only the space, the content needs](https://github.com/OpenTTD/website/assets/1734660/992d8c1b-cf7e-407a-aeb0-2ff0c086577e)

Screenshot 2 showns the same page, same scale as in screenshot 1 with the flexbox stretching the element `main`.

![Screenshot 2, page takes the whole space because of the stretched element main](https://github.com/OpenTTD/website/assets/1734660/1123ca66-2a35-4b54-a5f0-8c5897aa1568)
