### PR TITLE
Add: Add link to Liberapay on the donation page

### DIFF
--- a/pages/donate.html
+++ b/pages/donate.html
@@ -11,7 +11,7 @@ permalink: /donate.html
     </div>
     <div class="section-item">
         <div class="content">
-            <p>If you enjoy playing OpenTTD and would like to help support its development, please consider donating. OpenTTD is developed and released free of charge, and the developers give up their own free time to work on the game. In addition the server used to build the <a href="https://www.openttd.org/downloads/openttd-releases/latest.html">releases</a> and host the <a href="https://wiki.openttd.org/en/Community/Community">web services</a> costs a lot of money to run, so any support would be appreciated.</p>
+            <p>If you enjoy playing OpenTTD and would like to help support its development, please consider donating. OpenTTD is developed and released free of charge, and the developers give up their own free time to work on the game. In addition the server infrastructure used to build the <a href="https://www.openttd.org/downloads/openttd-releases/latest.html">releases</a> and host the <a href="https://wiki.openttd.org/en/Community/Community">web services</a> costs a lot of money to run, so any support would be appreciated.</p>
             <p>If you would like to support OpenTTD, donations can be made in a number of ways:</p>
             <ul class="section-list">
                 <li>
@@ -25,9 +25,15 @@ permalink: /donate.html
                         If you have any queries or wish to donate from another country, please contact <a href="mailto:orudge@openttd.org">Owen Rudge</a>.</div>
                 </li>
                 <li>
+                    <div class="header">Liberapay</div>
+                    <div class="contents">
+                        <a href="https://liberapay.com/OpenTTD">Liberapay</a> allows you to make one-off or recurring donations by credit or debit card, SEPA Direct Debit, or PayPal. If you'd like to set up a weekly, monthly or annual donation, Liberapay is the easiest way to do so. Donations accepted in over 30 different currencies.
+                    </div>
+                </li>
+                <li>
                     <div class="header">PayPal</div>
                     <div class="content">
-                        <a href="https://www.paypal.com/">PayPal</a> is the most common and perhaps the easiest way to make a donation. You can specify an amount to donate, in any currency supported by PayPal, and if you don't have a PayPal account, you can pay by credit/debit card without signing up for an account. If you would like to donate in this way, please click one of the following links:
+                        <a href="https://www.paypal.com/">PayPal</a> is one of the easiest ways to make a donation. You can specify an amount to donate, in any currency supported by PayPal, and if you don't have a PayPal account, you can pay by credit/debit card without signing up for an account. If you would like to donate in this way, please click one of the following links:
                         <ul>
                             <li><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&amp;business=owen%40owenrudge%2enet&amp;item_name=OpenTTD&amp;no_shipping=0&amp;no_note=1&amp;tax=0&amp;currency_code=GBP&amp;bn=PP%2dDonationsBF&amp;charset=UTF%2d8">Donate in British Pounds (GBP)</a></li>
                             <li><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&amp;business=owen%40owenrudge%2enet&amp;item_name=OpenTTD&amp;no_shipping=0&amp;no_note=1&amp;tax=0&amp;currency_code=USD&amp;bn=PP%2dDonationsBF&amp;charset=UTF%2d8">Donate in US Dollars (USD)</a></li>


### PR DESCRIPTION
Liberapay offers a free method for setting up and managing subscriptions (unlike, for instance, Patreon), which has been requested by at least one donor. Doesn't seem to be any reason not to try it.