### PR TITLE
Fix: Use correct class for Liberapay <div>

### DIFF
--- a/pages/donate.html
+++ b/pages/donate.html
@@ -26,7 +26,7 @@ permalink: /donate.html
                 </li>
                 <li>
                     <div class="header">Liberapay</div>
-                    <div class="contents">
+                    <div class="content">
                         <a href="https://liberapay.com/OpenTTD">Liberapay</a> allows you to make one-off or recurring donations by credit or debit card, SEPA Direct Debit, or PayPal. If you'd like to set up a weekly, monthly or annual donation, Liberapay is the easiest way to do so. Donations accepted in over 30 different currencies.
                     </div>
                 </li>


### PR DESCRIPTION
Accidentally added an unnecessary 's' when adding the new Liberapay section to the donate page.