### PR TITLE
Fix: [CI] use alias as deployment URL

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
 
     environment:
       name: ${{ github.event_name == 'push' && 'Production' || 'Preview' }}
-      url: ${{ steps.pages.outputs.url }}
+      url: ${{ steps.pages.outputs.alias }}
 
     steps:
     - name: Checkout
@@ -63,4 +63,4 @@ jobs:
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         projectName: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
         directory: _site
-        branch: ${{ github.event_name == 'push' && github.ref_name || github.event_name == 'repository_dispatch' && 'main' || format('pull/{0}', github.event.pull_request.number) }}
+        branch: ${{ github.event_name == 'push' && github.ref_name || github.event_name == 'repository_dispatch' && 'main' || format('pr/{0}', github.event.pull_request.number) }}


### PR DESCRIPTION
The alias domain is the same for the same Pull Request, no matter how often you push. This makes sharing the link easier.

While at it, rename "pull/N" to "pr/N", as it is a pull request; not a pull.

For the curious, see: https://github.com/cloudflare/pages-action#outputs