### PR TITLE
Rework of the footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -81,11 +81,11 @@
             {{ content }}
         </main>
         <footer>
-            <div id="content-bottom-links">
-                <a href="{{ site.baseurl }}/policy.html">Privacy Policy</a> |
-                <a href="{{ site.baseurl }}/content-creators.html">Content Creation Guidelines</a> |
-                <a href="{{ site.baseurl }}/contact.html">Contact</a>
-            </div>
+            <ul id="content-bottom-links">
+                <li><a href="{{ site.baseurl }}/policy.html">Privacy Policy</a></li>
+                <li><a href="{{ site.baseurl }}/content-creators.html">Content Creation Guidelines</a></li>
+                <li><a href="{{ site.baseurl }}/contact.html">Contact</a></li>
+            </ul>
              <div id="content-bottom-copyright">
                     Copyright &copy; 2005-{{ site.time | date: '%Y' }} OpenTTD Team
             </div>

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -169,6 +169,8 @@ main {
 	flex: 1;
 }
 body > footer {
+	display: flex;
+	justify-content: space-between;
 	background-color: white;
 	margin: 0 auto 36px auto;
 	padding: 7px 7px 6px 7px;
@@ -177,12 +179,10 @@ body > footer {
 	box-shadow: 0 0 3px 3px rgba(0, 0, 0, 0.11);
 }
 #content-bottom-links {
-	float: left;
 	font-size: 11px;
 	padding: 3px 5px;
 }
 #content-bottom-copyright {
-	float: right;
 	font-size: 11px;
 	padding: 3px 5px;
 }

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -181,6 +181,21 @@ body > footer {
 #content-bottom-links {
 	font-size: 11px;
 	padding: 3px 5px;
+	display: flex;
+	list-style: none;
+	margin: 0;
+}
+#content-bottom-links li:not(:last-child)::after {
+	content: "|";
+}
+#content-bottom-links li a {
+	display: inline-block;
+}
+#content-bottom-links li:not(:first-child) a {
+	margin-left: 3px;
+}
+#content-bottom-links li:not(:last-child) a {
+	margin-right: 3px;
 }
 #content-bottom-copyright {
 	font-size: 11px;

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -178,9 +178,11 @@ body > footer {
 	border-radius: 5px;
 	box-shadow: 0 0 3px 3px rgba(0, 0, 0, 0.11);
 }
-#content-bottom-links {
+body > footer > * {
 	font-size: 11px;
 	padding: 3px 5px;
+}
+#content-bottom-links {
 	display: flex;
 	list-style: none;
 	margin: 0;
@@ -196,10 +198,6 @@ body > footer {
 }
 #content-bottom-links li:not(:last-child) a {
 	margin-right: 3px;
-}
-#content-bottom-copyright {
-	font-size: 11px;
-	padding: 3px 5px;
 }
 #hr-clear {
 	clear: both;


### PR DESCRIPTION
Rework the page footer to a more modern structure.

## Remove the definition of floating childs of the footer

Replace it with a flexbox solution. That way we get rid of the floats, that are technically meant as a solution for floating an elements content around an element (group) but was used as a workaround for placing block elements in their parent boxes without nailing their position for many years. Nowadays we have much better solutions (flexbox or grid) with a wide and stable browser support.

## Rebuild the link list in the footer (`#content-bottom-links`)

Was a `div` with bare links and is now rebuilt as a real HTML-list.

## Move the link-separating pipes from HTML to CSS

I did this because the pipes (`|`) between the link titles are no content of the document but decoration for displaying it in a graphical browser. When the characters are in the HTML-source, a screenreader would read the pipes between the link titles but when inserted with CSS – as decoration – they are not part of the document and because of that are not read by a screenreader.

The pipes are inserted for all links of the list with exception of the last one. If the list gets extended or shortened in the future, the last link (maybe the only link) will not have a pipe behind itself but all other links (if present) will have one. Also the left and right margins are controlled by the position of the links in the list. The first link has no left margin and the last link has no right margin. Even this declaration will work with potentially changes of the number of list items.