### PR TITLE
Fix: [CI] upstream actions changed property names

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -57,13 +57,13 @@ jobs:
     name: Flake8
     uses: OpenTTD/actions/.github/workflows/rw-py-flake8.yml@v4
     with:
-      path: fetch_downloads
+      python-path: fetch_downloads
 
   black:
     name: Black
     uses: OpenTTD/actions/.github/workflows/rw-py-black.yml@v4
     with:
-      path: fetch_downloads
+      python-path: fetch_downloads
       python-version: 3.8
 
   annotation_check:


### PR DESCRIPTION
Basically, I broke the promise the API of an action / reusing workflow shouldn't change with the same major. As I did change things. Oops. This should fix it .. I hope :)

Edit: it does \o/