### PR TITLE
Add: 13.2 release announcement post

### DIFF
--- a/_posts/2023-06-10-openttd-13-2.md
+++ b/_posts/2023-06-10-openttd-13-2.md
@@ -1,0 +1,26 @@
+---
+title: OpenTTD 13.2
+author: LordAro
+---
+
+As I write this many of the development team and other members of the community are busy having fun at a meet-up in Brussels.
+Not me though, I'm stuck here doing a release.
+
+We've been busy refactoring quite a lot of the underlying code to make future changes easier, but along the way we've found and fixed a few more bugs and quality of life improvements that we figured were worth releasing sooner than whenever 14.0 comes along.
+
+Notably, OpenTTD will now automatically disable hardware acceleration if it detects that the last crash happened while initialising the graphics driver.
+While hardware acceleration works well for the vast majority of people, it causes crashes for people that then required command line arguments or manual config file editing to get it to work.
+This should be a better solution for those users.
+
+Additionally, there is a change to the default mouse mode on Linux to improve experience when dragging the map (and often to match expected behaviour in other games).
+
+As always, there are plenty of other bugfixes, which you can find in the changelog.
+
+While you're at it, have you seen the post about the upcoming addition of a automated opt-in survey to OpenTTD 14?
+If you have opinions, we'd like to hear them!
+[Details here](https://www.openttd.org/news/2023/05/14/policy-and-survey).
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/latest)
+* [Changelog](https://cdn.openttd.org/openttd-releases/13.2/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)
+


### PR DESCRIPTION
Reddit/Discord/TT-Forums:

```
As I write this many of the development team and other members of the community are busy having fun at a meet-up in Brussels. Not me though, I'm stuck here doing a release.

We've been busy refactoring quite a lot of the underlying code to make future changes easier, but along the way we've found and fixed a few more bugs and quality of life improvements that we figured were worth releasing sooner than whenever 14.0 comes along.

Notably, hardware acceleration should automatically disable itself if it detects an issue (crash) while initialising, and plenty of other crashing bugs have been fixed too.

Go check it out!
https://www.openttd.org/news/2023/06/10/openttd-13-2.html
```

Twitter:

```
OpenTTD 13.2 now available on Steam / our website.
https://www.openttd.org/news/2023/06/10/openttd-13-2.html
```

Steam:

???