### PR TITLE
Add: 13.3 release announcement post

### DIFF
--- a/_posts/2023-06-11-openttd-13-3.md
+++ b/_posts/2023-06-11-openttd-13-3.md
@@ -1,0 +1,46 @@
+---
+title: OpenTTD 13.3
+author: TrueBrain
+---
+
+Only a day after 13.2, we present 13.3.
+And there is a bit of a story here.
+
+But in short: we made a mistake with 13.2.1, and need to release a 13.3 with no functional change to make sure multiplayer games work as expected.
+
+<!-- more -->
+
+For the full story:
+
+Shortly after releasing 13.2 it was noticed that Windows users couldn't play on fullscreen mode anymore.
+This of course requires a quick new release (13.2.1), and as it was a fix only changing how a window on Windows is created, we wanted to make it compatible with 13.2.
+Our way of being nice, and not forcing everyone to upgrade before they can play together again.
+
+Well, we kinda failed in this department.
+
+The mentioned fix was trivial, and making sure a 13.2.1 client could join a 13.2 server (and the other way around) was trivial too.
+But we also noticed another mistake in the 13.2 release: Windows binaries still had 13.1 in their metadata.
+So why not fix that as well, right?
+
+Turns out, we overlooked a small thing: although the 13.2.1 client identifies as a 13.2 client in every way, the NewGRF validation does not.
+When you join a server two checks are done: is the client of the same version (13.2), and is the client using the same NewGRF revision.
+The first worked fine .. the second turns out to use the same field as the Windows binaries use for their metadata (and for all the right reasons, in case you are wondering).
+
+Oops.
+
+So basically, 13.2.1 is compatible with 13.2, but you can't actually join a 13.2 server with a 13.2.1 client (and the other way around) because of the NewGRF revision check.
+So our attempt in being nice kinda failed.
+
+The only resolution of which we know will work for sure is making a new release: 13.3.
+And that is all what this release is: a rebranding of 13.2.1, and no longer claim it is compatible with 13.2.
+Sadly, this does mean that all servers need updating again before clients who updated can join again.
+And all that because one tiny mistake in the 13.2 release.
+
+All that is left is to apologize for the inconvenience, but we hope you enjoy 13.2 (and the fix for Windows fullscreen in 13.2.1 / 13.3) nevertheless!
+
+And yes, we will try our at most to avoid a similar problem in the future!
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/latest)
+* [Changelog](https://cdn.openttd.org/openttd-releases/13.3/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)
+


### PR DESCRIPTION
For Discord:

```
@everyone

Oops .. turns out 13.2.1 didn't go as well as planned. So we made 13.3, which mostly aims to make sure multiplayer is working as expected again.

Want to read the full story? https://www.openttd.org/news/2023/06/11/openttd-13-3.html
```