### PR TITLE
Fix: remove any mention of 13.2.1

### DIFF
--- a/_posts/2023-06-10-openttd-13-2.md
+++ b/_posts/2023-06-10-openttd-13-2.md
@@ -24,6 +24,7 @@ PS: we made a mistake in the Windows release; a 13.2.1 was pushed to address thi
 It is fully network compatible with 13.2, so no need to update unless you want to.
 
 * [Download](https://www.openttd.org/downloads/openttd-releases/latest)
-* [Changelog](https://cdn.openttd.org/openttd-releases/13.2.1/changelog.txt)
+* [Changelog (13.2)](https://cdn.openttd.org/openttd-releases/13.2/changelog.txt)
+* [Changelog (13.2.1)](https://cdn.openttd.org/openttd-releases/13.2.1/changelog.txt)
 * [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)
 

--- a/_posts/2023-06-10-openttd-13-2.md
+++ b/_posts/2023-06-10-openttd-13-2.md
@@ -1,5 +1,5 @@
 ---
-title: OpenTTD 13.2 (and 13.2.1)
+title: OpenTTD 13.2
 author: LordAro
 ---
 
@@ -20,11 +20,7 @@ While you're at it, have you seen the post about the upcoming addition of a auto
 If you have opinions, we'd like to hear them!
 [Details here](https://www.openttd.org/news/2023/05/14/policy-and-survey).
 
-PS: we made a mistake in the Windows release; a 13.2.1 was pushed to address this issue.
-It is fully network compatible with 13.2, so no need to update unless you want to.
-
 * [Download](https://www.openttd.org/downloads/openttd-releases/latest)
-* [Changelog (13.2)](https://cdn.openttd.org/openttd-releases/13.2/changelog.txt)
-* [Changelog (13.2.1)](https://cdn.openttd.org/openttd-releases/13.2.1/changelog.txt)
+* [Changelog](https://cdn.openttd.org/openttd-releases/13.2/changelog.txt)
 * [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)
 


### PR DESCRIPTION
13.3 is a rebrand of 13.2.1, so no need to mention 13.2.1 anymore.

Fixes #265