### PR TITLE
Add: Release announcement for 13.4

### DIFF
--- a/_posts/2023-07-29-openttd-13-4.md
+++ b/_posts/2023-07-29-openttd-13-4.md
@@ -1,0 +1,15 @@
+---
+title: OpenTTD 13.4
+author: 2TallTyler
+---
+
+It's been a while since we've seen a .4 release, but quite a few people have reported a crash when a news item appears while a drop-down menu is open.
+
+Here's a fix for that, plus a few other fixes completed since the last release.
+
+<!-- more -->
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/latest)
+* [Changelog](https://cdn.openttd.org/openttd-releases/13.4/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)
+

--- a/_posts/2023-07-29-openttd-13-4.md
+++ b/_posts/2023-07-29-openttd-13-4.md
@@ -7,8 +7,6 @@ It's been a while since we've seen a .4 release, but quite a few people have rep
 
 Here's a fix for that, plus a few other fixes completed since the last release.
 
-<!-- more -->
-
 * [Download](https://www.openttd.org/downloads/openttd-releases/latest)
 * [Changelog](https://cdn.openttd.org/openttd-releases/13.4/changelog.txt)
 * [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Reddit/Discord/TT-Forums/Twitter (RIP)/Mastadon?/Etc?:
```
OpenTTD 13.4 now available on Steam/our website to fix a crash when a news item appears while a drop-down menu is open.
https://www.openttd.org/news/2023/07/29/openttd-13-4.html
```
Steam:
![News - 13 4 release](https://github.com/OpenTTD/website/assets/55058389/bee4b9df-2bdd-4ac3-bd60-4d7422939eff)
[News.-.13.4.release.zip](https://github.com/OpenTTD/website/files/12208022/News.-.13.4.release.zip)