### PR TITLE
Add: Release announcement for 14.0

### DIFF
--- a/_posts/2024-04-13-openttd-14-0.md
+++ b/_posts/2024-04-13-openttd-14-0.md
@@ -1,0 +1,125 @@
+---
+title: OpenTTD 14.0
+author: TrueBrain
+---
+
+Welcome to 14.0!
+
+OpenTTD's first release was in March of 2004.
+Now twenty years later, we are proud to present to you: release 14.0.
+
+And boy, what a release it is.
+Do I dare to say: this has been the biggest release yet?
+
+<!-- more -->
+
+Sometimes people try to tell us OpenTTD is dead.
+Well, 14.0 shows you it really isn't.
+There are so many new goodies in 14.0, that I don't even know where to start!
+Let's go over a few, just to get you a feel for what to expect when you launch OpenTTD 14.0.
+
+Read more about our birthday celebration post [here](https://www.openttd.org/news/2024/03/06/happy-birthday).
+
+## When one day isn't a day
+
+It is now possible to make the calendar time walk slower, up to a point it is frozen.
+This doesn't influence vehicle movement at all, nor the amount of goods transported, town growth, etc.
+But it does influence vehicle introduction dates, inflation, and aging.
+
+With this feature, we hope to enable different game-plays, where people want to have more time to build out their empire before vehicles expire, inflation gets too big, etc.
+
+A brand new day!
+For some a bit slower than others.
+
+Read more about this new feature [in the devblog](https://www.openttd.org/news/2024/03/23/timekeeping).
+
+## Ship Pathfinder
+
+The ship pathfinder got some great love.
+It is now capable of directing ships over vast distances without the need for buoys.
+In fact, one could say, you don't need buoys anymore at all.
+The ships will still find their way!
+
+Finally, no more "Ship is lost" non-sense.
+This enables ship-only games.
+
+Read more about this new feature [in the devblog](https://www.openttd.org/news/2024/02/24/new-ship-pathfinder).
+
+## Unbunching
+
+Do you also hate when busses start hugging each other on a route?
+And you so did your best to ensure you send them out the depot with a good distance of each other.
+But something must have happened down the road, and now they are very close to each other!
+
+Introducing: unbuncing.
+
+A new feature that allows you to tell all vehicles in a shared order pool to keep their distance; automatically, done for you.
+
+Read more about this new feature [in the devblog](https://www.openttd.org/news/2024/02/10/unbunching).
+
+## Social Platform integration
+
+OpenTTD 14.0 allows better integration with Social Platforms.
+This is totally optional, and has to be installed separately.
+But once done, OpenTTD can talk to platforms like Steam, Discord and GOG Galaxy.
+
+For now, the functionality is limited: friends can see you play OpenTTD, if you are in a server or not, and what kind of map you are playing.
+For future versions, we intend to expand on that, making more possible.
+But, small steps.
+
+Read more about this new feature [in the devblog](https://www.openttd.org/news/2024/03/02/social-integration).
+
+## Survey support
+
+To finally put a rest to endless debates about what setting is used and which is not, OpenTTD now has an opt-in survey tool built-in.
+Over time this will allow us, developers, to better understand how OpenTTD is played, so we can better anticipate what will be a hit or a miss.
+
+You can, at any time, opt in or out from the survey.
+
+Read more about this new feature [in the devblog](https://www.openttd.org/news/2024/03/16/survey-https-infra)
+
+## GUI improvements / scalable font
+
+There has been a huge effort in making all our windows just a tiny bit better.
+Fixing pixel-errors, moving things around a bit, fixing colouring issues.
+
+But .. not less important, we now also have a built-in scalable font!
+Zephyris created a real (TTF) font heavily inspired by the sprite font.
+This means that scaling looks a lot better, especially for zoom levels like 1.5x.
+
+We love it so much, it is the default when you launch the game! (but no worries, you can revert to the sprite font if you really want to).
+
+Read more about this new feature [in the devblog](https://www.openttd.org/news/2024/02/17/openttd-truetype-fonts).
+
+## New players experience
+
+First of all, there is now a Help and Manuals button in-game, that helps you through the basic information of the game.
+Bringing information closer to the user, and the game more accessible to everyone, has been a path we have been on for a while.
+
+Second, we revised a lot of settings, what their default value should be.
+Many settings have had their defaults changed, mostly towards enabling modern features by default.
+
+Lastly, we also renamed Cheats to Sandbox.
+We noticed people were struggling with using "cheats", as we have been conditioned that cheats in games are bad.
+But Cheats in OpenTTD context is much more "play how you like" (read: Sandbox).
+So we renamed it, hopefully making it more clear to new players that it is perfectly okay to uses these Sandbox options any time they like.
+
+Hopefully this helps new players get into the game easier.
+
+## So much more ...
+
+In total OpenTTD 14.0 comes with roughly 40 new features, over 500 bug-fixes, 200 changes, and many many code improvements.
+
+It took us 2,000 commits to get from 13.4 to 14.0, we touched 140,000 lines of code and removed 74,000 of them.
+This was all done by over 60 contributors.
+
+Interested how this all came together?
+Check out [our blog post](https://www.openttd.org/news/2024/03/09/how-its-made) explaining it all.
+
+A great thank you to all who contributed, with code or by support; it is truly appreciated!
+Up to another twenty years of OpenTTD development!
+
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/latest.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/14.0/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)

--- a/_posts/2024-04-13-openttd-14-0.md
+++ b/_posts/2024-04-13-openttd-14-0.md
@@ -18,7 +18,7 @@ Well, 14.0 shows you it really isn't.
 There are so many new goodies in 14.0, that I don't even know where to start!
 Let's go over a few, just to get you a feel for what to expect when you launch OpenTTD 14.0.
 
-Read more about our birthday celebration post [here](https://www.openttd.org/news/2024/03/06/happy-birthday).
+Read more about our birthday celebration [here](https://www.openttd.org/news/2024/03/06/happy-birthday).
 
 ## When one day isn't a day
 
@@ -48,10 +48,10 @@ Read more about this new feature [in the devblog](https://www.openttd.org/news/2
 ## Unbunching
 
 Do you also hate when busses start hugging each other on a route?
-And you so did your best to ensure you send them out the depot with a good distance of each other.
+And you did your best to ensure you send them out the depot with a good distance between them.
 But something must have happened down the road, and now they are very close to each other!
 
-Introducing: unbuncing.
+Introducing: unbunching.
 
 A new feature that allows you to tell all vehicles in a shared order pool to keep their distance; automatically, done for you.
 
@@ -102,7 +102,7 @@ Many settings have had their defaults changed, mostly towards enabling modern fe
 Lastly, we also renamed Cheats to Sandbox.
 We noticed people were struggling with using "cheats", as we have been conditioned that cheats in games are bad.
 But Cheats in OpenTTD context is much more "play how you like" (read: Sandbox).
-So we renamed it, hopefully making it more clear to new players that it is perfectly okay to uses these Sandbox options any time they like.
+So we renamed it, hopefully making it more clear to new players that it is perfectly okay to use these Sandbox options any time they like.
 
 Hopefully this helps new players get into the game easier.
 
@@ -116,8 +116,8 @@ This was all done by over 60 contributors.
 Interested how this all came together?
 Check out [our blog post](https://www.openttd.org/news/2024/03/09/how-its-made) explaining it all.
 
-A great thank you to all who contributed, with code or by support; it is truly appreciated!
-Up to another twenty years of OpenTTD development!
+A great thank you to all who contributed, with code or support; it is truly appreciated!
+Here's to another twenty years of OpenTTD development!
 
 
 * [Download](https://www.openttd.org/downloads/openttd-releases/latest.html)


### PR DESCRIPTION
![Openttd_14_release](https://github.com/OpenTTD/website/assets/68320206/acf1e8ec-b9a5-4fd3-8e7b-6f2cd79e5a09)
[Openttd_14_release.zip](https://github.com/OpenTTD/website/files/14942565/Openttd_14_release.zip)

Steam:
```
Welcome to 14.0!

OpenTTD's first release was in March of 2004.
Now twenty years later, we are proud to present to you: release 14.0.

<image>

And boy, what a release it is.
Do I dare to say: this has been the biggest release yet?

Sometimes people try to tell us OpenTTD is dead.
Well, 14.0 shows you it really isn't.
There are so many new goodies in 14.0, that I don't even know where to start!
Let's go over a few, just to get you a feel for what to expect when you launch OpenTTD 14.0.
```

Discord / Reddit / Mastodon / ...
```
Welcome to 14.0!

OpenTTD's first release was in March of 2004.
Now twenty years later, we are proud to present to you: release 14.0.

And boy, what a release it is.
Do I dare to say: this has been the biggest release yet?

https://www.openttd.org/news/2024/04/13/openttd-14-0

<image>
```

Only do the last two lines if the social platform actually supports attaching images :)