### PR TITLE
Add: 14.0-beta1 announcement

### DIFF
--- a/_posts/2024-02-03-openttd-14-0-beta1.md
+++ b/_posts/2024-02-03-openttd-14-0-beta1.md
@@ -1,0 +1,29 @@
+---
+title: OpenTTD 14.0-beta1
+author: TrueBrain
+---
+
+To celebrate that OpenTTD exists for 20 years this year, we are working towards a release packed with many new features to play with.
+
+40 new features, 80 changes, almost 150 fixes, it really is packed.
+In the upcoming weeks we will explain more in-depth what some of these new features are and how they work, but for now, we need your help.
+
+With this first testing release of the 14.X release series, we hope to squash as many bugs as possible before the actual release.
+Which means we need as many people as possible to test this upcoming new version.
+
+To guide you a bit towards what you should be looking for:
+* Generic gameplay bugs and crashes.
+* There is a new Ship Pathfinder; test it out. Buoys are optional to use.
+* You can now automatically unbunch your vehicles at a depot.
+* We added our own interpretation of daylength to the game. More on this soon in another blog post.
+* There are many GUI improvements throughout the game. More consistent look, better GUI scaling.
+
+There are many more things worth talking about, and this will be made more clear when we approach the release of 14.0.
+But for now, play the game, and please report any issues you find.
+
+The usual titlegame competition has also been [announced on the forums](https://www.tt-forums.net/viewtopic.php?t=91448).
+See the page for the exact competition rules if you are interested.
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/14.0-beta1/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)

--- a/_posts/2024-02-03-openttd-14-0-beta1.md
+++ b/_posts/2024-02-03-openttd-14-0-beta1.md
@@ -8,7 +8,7 @@ OpenTTD turns 20 this year, and to celebrate we are preparing for one of our lar
 It's packed with 40 new features, 80 changes, and almost 150 fixes.
 In the upcoming weeks we will share more posts explaining some of these features in depth. For now, we need your help testing our work.
 
-We need as many people as possible to test this beta version of the 14.X release series, so you can find and we can squash as many many bugs as possible before the actual release.
+We need as many people as possible to test this beta version of the 14.X release series, so you can find and we can squash as many bugs as possible before the actual release.
 
 To guide you a bit towards what you should be looking for:
 * Generic gameplay bugs and crashes.

--- a/_posts/2024-02-03-openttd-14-0-beta1.md
+++ b/_posts/2024-02-03-openttd-14-0-beta1.md
@@ -3,13 +3,12 @@ title: OpenTTD 14.0-beta1
 author: TrueBrain
 ---
 
-To celebrate that OpenTTD exists for 20 years this year, we are working towards a release packed with many new features to play with.
+OpenTTD turns 20 this year, and to celebrate we are preparing for one of our largest ever releases.
 
-40 new features, 80 changes, almost 150 fixes, it really is packed.
-In the upcoming weeks we will explain more in-depth what some of these new features are and how they work, but for now, we need your help.
+It's packed with 40 new features, 80 changes, and almost 150 fixes.
+In the upcoming weeks we will share more posts explaining some of these features in depth. For now, we need your help testing our work.
 
-With this first testing release of the 14.X release series, we hope to squash as many bugs as possible before the actual release.
-Which means we need as many people as possible to test this upcoming new version.
+We need as many people as possible to test this beta version of the 14.X release series, so you can find and we can squash as many many bugs as possible before the actual release.
 
 To guide you a bit towards what you should be looking for:
 * Generic gameplay bugs and crashes.
@@ -19,7 +18,7 @@ To guide you a bit towards what you should be looking for:
 * There are many GUI improvements throughout the game. More consistent look, better GUI scaling.
 
 There are many more things worth talking about, and this will be made more clear when we approach the release of 14.0.
-But for now, play the game, and please report any issues you find.
+But for now, play the game, and please [report any issues](https://github.com/OpenTTD/OpenTTD/issues/new/choose) you find.
 
 The usual titlegame competition has also been [announced on the forums](https://www.tt-forums.net/viewtopic.php?t=91448).
 See the page for the exact competition rules if you are interested.


### PR DESCRIPTION
I kept the announcement simple and small. For 14.0 (see other PR) I do suggest we explain in much more detail what is going on. But doing that now feels premature, and ruining the party.

@2TallTyler promised to make a blog-post about daylength, but that will be its own post.

For now I mostly need help, someone creating a 14.0-beta1 release image for Steam.

Reddit/Discord/TT-Forums/Twitter (RIP)/Mastadon?/Etc?:
```
OpenTTD turns 20 this year, and to celebrate we are preparing for one of our largest ever releases.

It's packed with 40 new features, 80 changes, and almost 150 fixes.
In the upcoming weeks we will share more posts explaining some of these features in depth. For now, we need your help testing our work.

We need as many people as possible to test this beta version of the 14.X release series, so you can find and we can squash as many bugs as possible before the actual release.

https://www.openttd.org/news/2024/02/03/openttd-14-0-beta1
```
