### PR TITLE
Add: 14.0-beta2 announcement

### DIFF
--- a/_posts/2024-02-04-openttd-14-0-beta2.md
+++ b/_posts/2024-02-04-openttd-14-0-beta2.md
@@ -1,0 +1,19 @@
+---
+title: OpenTTD 14.0-beta2
+author: michi_cc
+---
+
+You found some bugs in the beta1-release, and we found a new beta.
+
+With this update, you can now safely signal to your hearts content again. The full changelog is linked below.
+
+Problems like this are exactly why we need you to test the game.
+Carry on playing the game, and please [report any issues](https://github.com/OpenTTD/OpenTTD/issues/new/choose) you find.
+And don't forget to watch this space for more information on OpenTTD 14.
+
+With the start of the beta cycle for OpenTTD 14, it's also a good time to help out with the various translations of the game.
+No matter if you are already a translator or want become one, head over to our [web translator](https://translator.openttd.org) if you like to help out.
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/14.0-beta2/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Crashes are bad.

Reddit/Discord/TT-Forums/Twitter (RIP)/Mastadon?/Etc?:
```
You found some bugs in the beta1-release, and we found a new beta.

With this update, you can now safely signal to your hearts content again.

We need as many people as possible to test this beta version of the 14.X release series, so you can find and we can squash as many bugs as possible before the actual release.

https://www.openttd.org/news/2024/02/04/openttd-14-0-beta2
```
