### PR TITLE
Add: 14.0-beta3 announcement

### DIFF
--- a/_posts/2024-02-06-openttd-14-0-beta3.md
+++ b/_posts/2024-02-06-openttd-14-0-beta3.md
@@ -1,0 +1,17 @@
+---
+title: OpenTTD 14.0-beta3
+author: michi_cc
+---
+
+Well, third times's the charm, or so they say.
+
+So let's try this again, shall we?
+With beta 3, we've restored the cargo types that went missing in the sub-artic and tropical climates.
+We've also included fixes for various other issues which are listed in the full changelog linked below.
+
+Thanks to the reports made by many of you, we could solve the issues quickly.
+But never fear if you've missed out so far, there are still a lot of treasures to hunt for in this beta. Please share your findings on our [issue tracker](https://github.com/OpenTTD/OpenTTD/issues/new/choose).
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/14.0-beta3/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)

--- a/_posts/2024-02-06-openttd-14-0-beta3.md
+++ b/_posts/2024-02-06-openttd-14-0-beta3.md
@@ -13,7 +13,7 @@ Thanks to the reports made by many of you, we could solve the issues quickly.
 But never fear if you've missed out so far, there are still a lot of treasures to hunt for in this beta. Please share your findings on our [issue tracker](https://github.com/OpenTTD/OpenTTD/issues/new/choose).
 
 And watch this space as we'll soon start with our feature posts about the new things coming with OpenTTD 14.
-In the first installment, you'll learn why buses don't always come when they should and what you can do against it.
+In the first installment, you'll learn why buses don't always come when they should and what you can do about it.
 
 * [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
 * [Changelog](https://cdn.openttd.org/openttd-releases/14.0-beta3/changelog.txt)

--- a/_posts/2024-02-06-openttd-14-0-beta3.md
+++ b/_posts/2024-02-06-openttd-14-0-beta3.md
@@ -12,6 +12,9 @@ We've also included fixes for various other issues which are listed in the full 
 Thanks to the reports made by many of you, we could solve the issues quickly.
 But never fear if you've missed out so far, there are still a lot of treasures to hunt for in this beta. Please share your findings on our [issue tracker](https://github.com/OpenTTD/OpenTTD/issues/new/choose).
 
+And watch this space as we'll soon start with our feature posts about the new things coming with OpenTTD 14.
+In the first installment, you'll learn why buses don't always come when they should and what you can do against it.
+
 * [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
 * [Changelog](https://cdn.openttd.org/openttd-releases/14.0-beta3/changelog.txt)
 * [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)

--- a/_posts/2024-02-06-openttd-14-0-beta3.md
+++ b/_posts/2024-02-06-openttd-14-0-beta3.md
@@ -3,7 +3,7 @@ title: OpenTTD 14.0-beta3
 author: michi_cc
 ---
 
-Well, third times's the charm, or so they say.
+Well, third time's the charm, or so they say.
 
 So let's try this again, shall we?
 With beta 3, we've restored the cargo types that went missing in the sub-artic and tropical climates.


### PR DESCRIPTION
Well, if anybody feels like making a release, here's a news message proposal. Don't forget to fix the posting date as needed.

Reddit/Discord/TT-Forums/Twitter (RIP)/Mastodon?/Etc?:
```
Well, third time's the charm, or so they say.

With the 3rd beta of OpenTTD 14, we've restored the cargo types that went missing from some climates.

Please come with us on the treasure hunt for bugs, so OpenTTD 14 can become the best OpenTTD ever.

https://www.openttd.org/news/2024/02/06/openttd-14-0-beta3
```
