### PR TITLE
Fix: [GitHub] Add exact Steam image dimensions to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 For news posts, please remember:
 
-- Should this be published on Steam? Please attach an image (see release posts for inspiration / dimensions)
+- Should this be published on Steam? Please attach an image (exactly 800x450px, see release posts for inspiration)
 - Should this be posted on Socials? Please attach a short text for that (see release posts for inspiration)
 
 -->


### PR DESCRIPTION
Mention exact Steam image dimensions (800x450px) in PR template