### PR TITLE
Add: 14.0-RC2 announcement

### DIFF
--- a/_posts/2024-03-16-openttd-14-0-RC2.md
+++ b/_posts/2024-03-16-openttd-14-0-RC2.md
@@ -1,6 +1,7 @@
 ---
 title: OpenTTD 14.0-RC2
 author: Kuhnovic
+date: 2024-03-16 13:00:00
 ---
 
 Today we release 14.0-RC2, the second release candidate for the upcoming release.

--- a/_posts/2024-03-16-openttd-14-0-RC2.md
+++ b/_posts/2024-03-16-openttd-14-0-RC2.md
@@ -1,0 +1,17 @@
+---
+title: OpenTTD 14.0-RC2
+author: Kuhnovic
+---
+
+Today we release 14.0-RC2, the second release candidate for the upcoming release.
+We've fixed a whole bunch of issues found in the first release candidate.
+However, there is a good chance there are still some issues out there that haven't been found yet.
+Please help us hunt those down, and if you find one, you can [report them here](https://github.com/OpenTTD/OpenTTD/issues/new/choose).
+
+Translation updates are coming in every day, most languages are complete or are nearing completion. 
+If you are a translator, please see if [your language has any missing translations](https://translator.openttd.org/project/openttd-master).
+We greatly appreciate your contribution!
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/14.0-RC2/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Announcement for 14.0 RC2


Reddit / Discord // tt-forums
```
OpenTTD 14.0 is soon to be released. You guys already worked hard to break the game, and we've been working hard to fix the issues you've reported. Today we release RC2 with all of the recent fixes.

Please help us hunt down the last bugs, and make sure you're having fun doing it! Your help is greatly appreciated!

https://www.openttd.org/news/2024/03/16/openttd-14-0-RC2
```

Xitter:
```
OpenTTD 14.0-RC2 now available! Please help us hunt down the last bugs!
https://www.openttd.org/news/2024/03/16/openttd-14-0-RC2
```