### PR TITLE
Add: message to GRFCodec download pages that those pages are effectively deprecated

### DIFF
--- a/_download-meta/grfcodec-nightlies.md
+++ b/_download-meta/grfcodec-nightlies.md
@@ -1,2 +1,4 @@
 ---
 ---
+
+Nightlies for GRFCodec are not created anymore. The latest source version can be found on [GitHub](https://github.com/OpenTTD/grfcodec).

--- a/_download-meta/grfcodec-releases.md
+++ b/_download-meta/grfcodec-releases.md
@@ -1,2 +1,4 @@
 ---
 ---
+
+Release builds for GRFCodec are not created anymore. The latest released version can be found on [GitHub](https://github.com/OpenTTD/grfcodec/releases).


### PR DESCRIPTION
GRFCodec builds are not released to the CDN, so people might get the idea that there is no newer version of GRFCodec. As such point them to the appropriate GitHub pages.

I'm not sure whether this is the best solution, alternatively the deployment of binaries gets fixed but that's not really something I got experience with.