### PR TITLE
Change: Add account name for UK bank account (required for verification)

### DIFF
--- a/pages/donate.html
+++ b/pages/donate.html
@@ -18,7 +18,7 @@ permalink: /donate.html
                     <div class="header">Bank transfer</div>
                     <div class="content">A direct bank transfer is generally the cheapest way to donate, if you have a GBP, USD or EUR bank account. Please note that this may incur charges from your bank otherwise. You can use the following bank details to donate. Please note that the accounts listed below will only accept transfers from the countries specified.
                         <ul>
-                            <li><b>GBP (United Kingdom)</b>: Account number <b>75798685</b>, sort code <b>23-14-70</b></li>
+                            <li><b>GBP (United Kingdom)</b>: Account number <b>75798685</b>, sort code <b>23-14-70</b>, account name <b>Owen Rudge</b></li>
                             <li><b>USD (United States)</b>: Please e-mail <a href="mailto:orudge@openttd.org">Owen Rudge</a> for details</li>
                             <li><b>EUR (Eurozone)</b>: IBAN <b>BE65 9670 3187 7596</b>, BIC <b>TRWIBEB1XXX</b></li>
                         </ul>


### PR DESCRIPTION
Bank transfers in the UK now generally require the account name to be provided, for validation. Scary warnings appear if you don't have this.