### PR TITLE
Fix #330: replace changelog.txt with changelog.md in the changelog link on the download page

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -34,7 +34,7 @@ js:
         <div class="content">
             <p>Latest {{ page.name }} release in {{ page.category }} is {{ page.version }}, released on {{ page.date | date: "%Y-%m-%d %H:%M" }} UTC.</p>
 
-            <div class="changelog">[&nbsp;<a href="https://cdn.openttd.org/{{ folder }}/changelog.txt">Changelog</a>&nbsp;]</div>
+            <div class="changelog">[&nbsp;<a href="https://cdn.openttd.org/{{ folder }}/changelog.md">Changelog</a>&nbsp;]</div>
             <div id="download-combo">
                 <input type="hidden" id="download-combo-state" value="" />
                 <input type="hidden" id="download-base-name" value="{{ page.base }}" />


### PR DESCRIPTION
This fixes #330. The change is necessary to reflect the change of the filetype of the changelog file in OpenTTD/OpenTTD#12994. I have not found a link to the file known-bugs.txt whose file type was also changed in pull request OpenTTD/OpenTTD#12994.