### PR TITLE
Add: 15.0-beta1 announcement

### DIFF
--- a/_posts/2024-12-24-openttd-15-0-beta1.md
+++ b/_posts/2024-12-24-openttd-15-0-beta1.md
@@ -1,0 +1,27 @@
+---
+title: OpenTTD 15.0-beta1
+author: michi_cc
+---
+
+Ho, ho, ho, Santa is in town.
+And he's brought a gift with him.
+
+Here's a shiny new package for you to unwrap, containing the first beta release of the upcoming OpenTTD 15 version.
+
+
+
+Some of the main features and changes are:
+* Improved picker windows for stations/waypoints/objects/and more. Oh, and that does include road waypoints.
+* Better perfomance in various places, including faster path signals that are now green by default.
+* Password-less network authentication using keys.
+* Several improvements for NewGRFs regarding cargo support.
+* Better scenario editor with a town data importer and manual house placement.
+* A large tree fully hung with ornamental bugfixes.
+* Sadly though, not everbody was good this year. The old NPF pathfinder was finally retired, after YAPF being the superior default for many, many years now.
+
+We need as many people as possible to test this beta version of the 15.X release series, so you can find and we can squash as many bugs as possible before the actual release.
+But for now, play the game, and please [report any issues](https://github.com/OpenTTD/OpenTTD/issues/new/choose) you find.
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/15.0-beta1/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)

--- a/_posts/2024-12-24-openttd-15-0-beta1.md
+++ b/_posts/2024-12-24-openttd-15-0-beta1.md
@@ -8,7 +8,7 @@ And he's brought a gift with him.
 
 Here's a shiny new package for you to unwrap, containing the first beta version of the upcoming OpenTTD 15 release.
 
-It comes faster, with road waypoints, less passwords, better scenario editor, and hopefully with a lot less bugs.
+It comes faster, with road waypoints, fewer passwords, better scenario editor, and hopefully with a lot less bugs.
 To be a bit less vague, here are some of the highlights:
 * Improved picker windows for stations/waypoints/objects/and more. Oh, and that does include road waypoints.
 * Better perfomance in various places, including faster path signals that are now green by default.

--- a/_posts/2024-12-24-openttd-15-0-beta1.md
+++ b/_posts/2024-12-24-openttd-15-0-beta1.md
@@ -6,11 +6,10 @@ author: michi_cc
 Ho, ho, ho, Santa is in town.
 And he's brought a gift with him.
 
-Here's a shiny new package for you to unwrap, containing the first beta release of the upcoming OpenTTD 15 version.
+Here's a shiny new package for you to unwrap, containing the first beta version of the upcoming OpenTTD 15 release.
 
-
-
-Some of the main features and changes are:
+It comes faster, with road waypoints, less passwords, better scenario editor, and hopefully with a lot less bugs.
+To be a bit less vague, here are some of the highlights:
 * Improved picker windows for stations/waypoints/objects/and more. Oh, and that does include road waypoints.
 * Better perfomance in various places, including faster path signals that are now green by default.
 * Password-less network authentication using keys.
@@ -19,8 +18,7 @@ Some of the main features and changes are:
 * A large tree fully hung with ornamental bugfixes.
 * Sadly though, not everbody was good this year. The old NPF pathfinder was finally retired, after YAPF being the superior default for many, many years now.
 
-We need as many people as possible to test this beta version of the 15.X release series, so you can find and we can squash as many bugs as possible before the actual release.
-But for now, play the game, and please [report any issues](https://github.com/OpenTTD/OpenTTD/issues/new/choose) you find.
+There's a lot of bugs left for you to find, though, guaranteed. Enjoy the beta, test all the things and [report anything you find amiss](https://github.com/OpenTTD/OpenTTD/issues/new/choose), to make OpenTTD 15 the best OpenTTD 15 ever.
 
 * [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
 * [Changelog](https://cdn.openttd.org/openttd-releases/15.0-beta1/changelog.txt)


### PR DESCRIPTION
<!--

For news posts, please remember:

- Should this be published on Steam? Please attach an image (exactly 800x450px, see release posts for inspiration)
- Should this be posted on Socials? Please attach a short text for that (see release posts for inspiration)

-->

Well, someone started with updating the changelog for a release, so let's motivate a bit more, just in case 😄 

Reddit/Discord/TT-Forums/Twitter (RIP)/Mastadon?/Etc?:
```
Ho, ho, ho, Santa is in town. And he's brought a gift with him.

The first beta version of the coming OpenTTD 15 release comes faster, with road waypoints, fewer passwords, better scenario editor, and hopefully with a lot less bugs.

There's a lot of bugs left for you to find, though, guaranteed. Enjoy the beta, test all the things and report anything you find amiss, to make OpenTTD 15 the best OpenTTD ever.

https://www.openttd.org/news/2024/12/24/openttd-15-0-beta1
```