### PR TITLE
Fix #330: Markdown changelog links

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -34,7 +34,7 @@ js:
         <div class="content">
             <p>Latest {{ page.name }} release in {{ page.category }} is {{ page.version }}, released on {{ page.date | date: "%Y-%m-%d %H:%M" }} UTC.</p>
 
-            {% assign markdowndate = '22-10-2024' | date: '%s' %}
+            {% assign markdowndate = '2024-10-22' | date: '%s' %}
             {% assign versiondate = page.date | date: '%s' %}
             {% if versiondate > markdowndate && raw_type contains "openttd" %}
             <div class="changelog">[&nbsp;<a href="https://cdn.openttd.org/{{ folder }}/changelog.md">Changelog</a>&nbsp;]</div>


### PR DESCRIPTION
Closes #330.

Fix the links in download pages and 15.0-beta1 blogpost to point to the new changelog locations.

For 15.0-beta1, this will still point to an empty page since the actually generated changelog is broken (see OpenTTD/OpenTTD#13195).

Is there any other place where changelogs are linked?