### PR TITLE
Fix: name groups in dependabot for what they are

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: "monthly"
   groups:
-    dependencies:
+    python:
       patterns:
       - "*"
 - package-ecosystem: "bundler"
@@ -13,7 +13,7 @@ updates:
   schedule:
     interval: "monthly"
   groups:
-    regression:
+    ruby:
       patterns:
       - "*"
 - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!--

For news posts, please remember:

- Should this be published on Steam? Please attach an image (exactly 800x450px, see release posts for inspiration)
- Should this be posted on Socials? Please attach a short text for that (see release posts for inspiration)

-->