### PR TITLE
Add: OpenTTD 15.0-beta2 announcement

### DIFF
--- a/_posts/2025-03-29-openttd-15-0-beta2.md
+++ b/_posts/2025-03-29-openttd-15-0-beta2.md
@@ -1,0 +1,27 @@
+---
+title: OpenTTD 15.0-beta2
+author: 2TallTyler
+---
+
+It's nearly April 1st, but bugs are no joke.
+
+We've fixed a bunch more since beta1, and need more testing. Also, we added some new features! Highlights include:
+* Snow-covered rocks are now visible
+* Steep hills from map generation or heightmap import now get extra rocks
+* Houses can be individually placed by players in the scenario editor and (if enabled) in-game, and can be protected from replacement during town growth
+* Touchpad two-finger map scrolling for Windows
+* NewGRF Badges
+* A variety of bugfixes
+
+(As always, see the changelog for further details).
+
+What are badges, you ask? Badges are something add-on (NewGRF) authors can put on their content to help you find e.g. the vehicle or station you want to use.
+For example, various vehicle add-ons use a mix of different icons, overlay images or texts to indicate the power source or the suggested usage of a vehicle. With badges, this information can be represented in a clear way including built-in filtering, that is cohesive between different add-ons.
+
+As this beta is the first release featuring badge support, there aren't many updated add-ons yet, but we're excited to see what authors do with the new feature.
+
+Finally, the usual titlegame competition has been [announced on the forums](https://www.tt-forums.net/viewtopic.php?t=92166).
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/15.0-beta2/changelog.txt)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)

--- a/_posts/2025-04-13-openttd-15-0-beta2.md
+++ b/_posts/2025-04-13-openttd-15-0-beta2.md
@@ -3,7 +3,7 @@ title: OpenTTD 15.0-beta2
 author: 2TallTyler
 ---
 
-It's nearly April 1st, but bugs are no joke.
+April 1st has come and gone, but have no fear, for beta2 is here.
 
 We've fixed a bunch more since beta1, and need more testing. Also, we added some new features! Highlights include:
 * Snow-covered rocks are now visible


### PR DESCRIPTION
Long social message (Reddit / Discord / TT-Forums):

```
April 1st has come and gone, but have no fear, for a new OpenTTD 15 beta release is here.

It includes new features like an option to let players place town houses, more rocks, snowy rocks, and touchpad scrolling on Windows, plus a bunch of bugfixes.

Check it out and help us test!

https://www.openttd.org/news/2025/04/13/openttd-15-0-beta2.html
```

Short social message:
```
OpenTTD 15.0-beta2 now available on Steam / our website.
Place houses and look out for increased rocks.
https://www.openttd.org/news/2025/04/13/openttd-15-0-beta2.html
```

Steam:
Steam image below by Zephyris!

<!--

For news posts, please remember:

- Should this be published on Steam? Please attach an image (exactly 800x450px, see release posts for inspiration)
- Should this be posted on Socials? Please attach a short text for that (see release posts for inspiration)

-->