### PR TITLE
Clarify the navigation bar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,7 +58,8 @@
                 <li class="{% if page.active_nav == 'about' %}selected{% endif %}">
                     <a href="{{ site.baseurl }}/about.html">About</a>
                 </li>
-                <li><a href="https://wiki.openttd.org/">Manual</a></li>
+                <li><a href="https://wiki.openttd.org/en/Manual/">Manual</a></li>
+                <li><a href="https://wiki.openttd.org/">Wiki</a></li>
                 <li class="{% if page.active_nav == 'screenshots' or layout.active_nav == 'screenshots' %}selected{% endif %}">
                     <a href="{{ site.baseurl }}/screenshots.html">Screenshots</a>
                 </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -67,7 +67,6 @@
                 <li class="{% if page.active_nav == 'development' %}selected{% endif %}">
                     <a href="{{ site.baseurl }}/development.html">Development</a>
                 </li>
-                <li><a href="https://forum.openttd.org/">Forum</a></li>
                 <li><a href="https://wiki.openttd.org/en/Community/Community">Community</a></li>
                 <li class="{% if page.active_nav == 'contact' %}selected{% endif %}">
                     <a href="{{ site.baseurl }}/contact.html">Contact</a>


### PR DESCRIPTION
Before this PR:
Clicking the _Manual_ button on the navigation bar would lead to OpenTTD's wiki. There were two buttons to access the [TT-Forums](https://www.tt-forums.net/): _Forum_ and _Community_.

This PR:
The _Manual_ button and its wiki link has been split into two buttons: _Manual_ and _Wiki_ (I considered renaming the button, "Manual/Wiki" but the slash looked odd). TT-Forums is already listed as an option among others when clicking the _Community_ button so I removed its spot from the navigation menu (maybe it would be beneficial to have it featured above all the others on the community page?).