### PR TITLE
Add: OpenTTD 15.0-beta3 announcement

### DIFF
--- a/_posts/2025-08-31-openttd-15-0-beta3.md
+++ b/_posts/2025-08-31-openttd-15-0-beta3.md
@@ -1,0 +1,25 @@
+---
+title: OpenTTD 15.0-beta3
+author: 2TallTyler
+---
+
+Did you have a lazy summer? Over at OpenTTD HQ, we did not!
+
+We've continued to make improvements to OpenTTD, both very visible to player and under the hood. It's time for another beta so you can help us test. Highlights include:
+* Bridges can now be built over stations (NewGRF stations must be updated to support this)
+* [NewGRF] Bridge GRFs can now have pillar information, so that a pillar can be skipped if it obstructs the tile below (rail, road, or station)
+* Ships traveling in opposite directions try not to drive on the same line of tiles
+* Purchase and picker menus can now be filtered using NewGRF Badges
+* Settings and Options menus have been merged
+* Scenario Editor has improvements for placing and expanding towns
+  * New buttons to expand town roads and buildings separately
+  * "Many random towns" button now prompts for the number of towns
+* Picker window sprite previews can be increased in height, so you can see the entire skyscraper in the house picker (for example)
+* The Infrastructure list window now has a scrollbar
+* A variety of bugfixes
+
+(As always, see the changelog for further details).
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/15.0-beta3/changelog.md)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
# Description

Long social message:

```
Having a lazy summer? Over at OpenTTD HQ, we are not!

We've been busy building bridges over stations, rerouting ships traveling in opposite directions, improving the user interface, adding support for NewGRF Badges, and fixing bugs.

Come help us test our work!
[link to OpenTTD.org news post]
```

Short social message:
```
OpenTTD 15.0-beta3 now available on Steam / our website.
You can now build bridges over stations!
[link to OpenTTD.org news post]
```

Steam image in the spirit of our new title game. 😄 
<img width="800" height="450" alt="News-15 0-beta3" src="https://github.com/user-attachments/assets/b2eb3a00-4cc7-4a10-b8b6-85eb85176e94" />
[News-15.0-beta3.zip](https://github.com/user-attachments/files/21181826/News-15.0-beta3.zip)

# To Do
- [x] Finish a few PRs from the [15.0 milestone](https://github.com/OpenTTD/OpenTTD/milestone/7)
- [ ] Update the post date before merging