### PR TITLE
Add: Announcement of Steam changes

### DIFF
--- a/_download-meta/openttd-releases.md
+++ b/_download-meta/openttd-releases.md
@@ -12,6 +12,8 @@ Sound and music sets are recommended (but not necessary).
 
 Additional graphics, sound, and music sets can be downloaded via the in-game content download manager.
 
+You can purchase Transport Tycoon Deluxe alongside OpenTTD on [Steam](https://store.steampowered.com/app/3766810/Transport_Tycoon_Deluxe) and [GOG](https://www.gog.com/game/transport_tycoon_deluxe).
+
 For integration with Social Platforms, you have to manually download and install the plugin of the platform (only available on OpenTTD 14.0 and later):
 - [Discord](../discord-social-releases/latest)
 - [GOG Galaxy](../gog-galaxy-social-releases/latest)

--- a/_posts/2026-03-14-steam-changes.md
+++ b/_posts/2026-03-14-steam-changes.md
@@ -1,0 +1,48 @@
+---
+title: Changes to OpenTTD distribution on Steam
+author: orudge
+---
+
+OpenTTD has been available on the Steam Store for the past five years.
+During that time, we've built up an incredible player base, attracting lots of new players to the game.
+Starting today however, OpenTTD will no longer be directly available as a standalone game on Steam.
+It can instead be obtained as part of a bundle alongside the original Transport Tycoon Deluxe, which has been re-released by Atari and is now available to purchase via Steam for Windows, Mac, and Linux.
+You can purchase the bundle [here](https://store.steampowered.com/app/3766810/Transport_Tycoon_Deluxe) for $9.99.
+
+Please read on for more details on this change.
+
+<!-- more -->
+
+## What does this mean for you?
+
+If you already own OpenTTD on Steam, nothing changes.
+You'll continue to receive game updates as usual.
+If you ever need to re-download the game, the game will remain in your Steam library.
+
+For any new players interested in owning OpenTTD on Steam or GOG, you will need to purchase the Transport Tycoon Deluxe / OpenTTD bundle, allowing access to both the original Transport Tycoon Deluxe and OpenTTD as separate products.
+
+## Wait, is the game no longer free?
+
+The game remains free.
+However, to download OpenTTD on Steam moving forward, you must purchase the original Transport Tycoon Deluxe game alongside it.
+
+## What is in the new Transport Tycoon Deluxe on Steam?
+
+It's a faithful emulation of Chris Sawyer's original Transport Tycoon Deluxe, now playable on modern machines.
+
+## What about other platforms and stores?
+
+The same change has been made on the GOG.com store.
+All other distribution platforms are unchanged, and you can continue to download OpenTTD from our web site.
+However if you enjoy playing OpenTTD but you were never able to purchase a copy of the original Transport Tycoon game, you now have the opportunity to do so!
+
+## Does this affect the future of OpenTTD?
+
+OpenTTD continues to be developed by a team of independent developers, supported entirely by you, the players.
+There has been no change to the development team, our workflow, or the open source nature of the project.
+We will continue to deliver new versions of OpenTTD to all platforms, including Steam and GOG.
+
+## Help and support
+
+If you want to ask questions about OpenTTD, make suggestions, or report bugs in the game, nothing has changed - see details [here](https://www.openttd.org/contact).
+Transport Tycoon Deluxe and the new Steam and GOG listings are managed and supported by [Atari](https://support.atari.com/).


### PR DESCRIPTION
Atari launched Transport Tycoon Deluxe on Steam and GOG yesterday. This post explains the changes that will be made to OpenTTD's listings on these stores as a result. We are still waiting for the Steam bundle to go live, so I will hold off on pushing this to the site until that's happened (and we can verify the pricing).