### PR TITLE
Add: Announcement post for 15.3

### DIFF
--- a/_posts/2026-04-04-openttd-15-3.md
+++ b/_posts/2026-04-04-openttd-15-3.md
@@ -1,0 +1,20 @@
+---
+title: OpenTTD 15.3
+author: 2TallTyler
+---
+
+It's April, time for a new OpenTTD version?
+
+Sort of. We're hard at work on features for OpenTTD 16, but in the meantime we've fixed a few bugs including a multiplayer desync triggered by train crashes.
+
+Fixes incude:
+
+* Don't desync multiplayer clients when a train crashes
+* When a helicopter runs out of fuel near the map edge, crash it within the map instead of the void (which crashes the whole game)
+* Improve appearance of toolbars and main menu images/text with some non-default base sets such as aBase, biggui, and original TTD
+
+If you find any more bugs, please [report them here](https://github.com/OpenTTD/OpenTTD/issues/new/choose).
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/latest.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/15.3/changelog.md)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Long news post:

```
We're hard at work on features for OpenTTD 16, but in the meantime we've fixed a few bugs including a multiplayer desync triggered by train crashes.

* Don't desync multiplayer clients when a train crashes
* When a helicopter runs out of fuel near the map edge, crash it within the map instead of the void (which crashes the whole game)
* Improve appearance of toolbars and main menu images/text with some non-default base sets such as aBase, biggui, and original TTD

Full news: https://www.openttd.org/news/2026/04/04/openttd-15-3
```

Short news post:
```
OpenTTD 15.3 fixes some bugs including a desync triggered by train crashes.
Full news: https://www.openttd.org/news/2026/04/04/openttd-15-3
```

News image:

<img width="800" height="450" alt="News-15 3" src="https://github.com/user-attachments/assets/38554741-c272-464a-8012-1cabba67340c" />

[News-15.3.zip](https://github.com/user-attachments/files/26472794/News-15.3.zip)