### PR TITLE
Fix 7c1b1df: Use the correct output variable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,4 +55,4 @@ jobs:
         -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
         -H "X-GitHub-Api-Version: 2026-03-10" \
         ${{ steps.deployment.outputs.url }} \
-        -d '{"state":"${{ job.status }}","log_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","environment_url":"${{ steps.pages.outputs.pages-deployment-alias-url }}","auto_inactive":false}'
+        -d '{"state":"${{ job.status }}","log_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","environment_url":"${{ steps.pages.outputs.pages-deployment-alias-url || steps.pages.outputs.deployment-url }}","auto_inactive":false}'


### PR DESCRIPTION
<!--

For news posts, please remember:

- Should this be published on Steam? Please attach an image (exactly 800x450px, see release posts for inspiration)
- Should this be posted on Socials? Please attach a short text for that (see release posts for inspiration)

-->
`pages-deployment-alias-url` is filled only for PRs, while `deployment-url` exists in all cases.

PR:
<img width="652" height="82" alt="image" src="https://github.com/user-attachments/assets/5a25b567-f727-44bd-b9c4-a24a4d7becd8" />
Non-PR:
<img width="659" height="58" alt="image" src="https://github.com/user-attachments/assets/8c574b9e-7851-48bb-9bd1-02614fb4af21" />
