### PR TITLE
Add: News post for 16.0-beta1 release

### DIFF
--- a/_posts/2026-06-25-openttd-16-0-beta1.md
+++ b/_posts/2026-06-25-openttd-16-0-beta1.md
@@ -1,0 +1,31 @@
+---
+title: OpenTTD 16.0-beta1
+author: 2TallTyler
+---
+
+We've been working on some exciting new features for OpenTTD 16, and they need testing!
+The first beta release is now available, and we've opened the competition to create the title game for the next release.
+
+<!-- more -->
+
+The first beta of OpenTTD 16 is now available with a host of new features including:
+
+* Trains can now drive backwards! ([read more](https://www.openttd.org/news/2026/06/25/backwards-driving))
+* Multiplayer companies can be set to allow anyone to join without needing an invite.
+* Map generation has been improved in many ways: Rocks on desert tiles, better coasts near map edges, better lighthouse spawning on large maps, transmitters only spawn after 1920, and custom control of average land height
+* Subsidies are now enabled for cargos which use CargoDist.
+* Create your own collections of saved NewGRF items in picker windows, including objects, stations, and houses.
+* Scale the aging rate of cargo payments, so slow vehicles on large maps can be profitable.
+* Dropdown lists now have text filters so you can find what you're looking for faster.
+* Vehicle preview offers have been combined into one window instead of spamming many windows.
+* Many more features, changes, and fixes, see the full changelog for details.
+
+We've also launched the [OpenTTD 16 Title Game Competition](https://www.tt-forums.net/viewtopic.php?t=92812) over on TT-Forums.
+This is your chance to design and later vote on the game which plays behind the main menu.
+(Yes, the current Toyland game was created and chosen by you, the community!)
+
+If you find any bugs, please [report them here](https://github.com/OpenTTD/OpenTTD/issues/new/choose).
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/16.0-beta1/changelog.md)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Let's get 16.0-beta1 out soon.

I welcome opinions on what should be shared in the overview, it's a big changelog and not everything fits. 🙂 

### Long socials post
```
OpenTTD 16.0-beta1 is out for testing! Features include:
* New options for trains to drive backwards instead of flipping
* Setting for open multiplayer companies where anyone can join
* More features and bugfixes!

Full news: https://www.openttd.org/news/2026/06/25/openttd-16-0-beta1
```

### Short socials post
```
OpenTTD 16.0-beta1 is out for testing. Trains can go backwards!
Full news: https://www.openttd.org/news/2026/06/25/openttd-16-0-beta1
```

### News image
<img width="800" height="450" alt="News-16 0-beta1" src="https://github.com/user-attachments/assets/1270e7d8-46e0-454e-8ab1-ba7c2c7d9ac7" />

[News-16.0-beta1.zip](https://github.com/user-attachments/files/28919059/News-16.0-beta1.zip)

### To Do

- [x] Write socials text
- [x] Create news image
- [x] Before publishing: change URL of linked Backwards Driving post (#394) to reflect the date when that is actually published
- [x] Before publishing: add link to TT-Forums title game competition post
