### PR TITLE
Add: Release post for 16.0-beta2

### DIFF
--- a/_posts/2026-07-12-openttd-16-0-beta2.md
+++ b/_posts/2026-07-12-openttd-16-0-beta2.md
@@ -1,0 +1,26 @@
+---
+title: OpenTTD 16.0-beta2
+author: 2TallTyler
+---
+
+Bugs? Fixed. Features? Added. Time for a second beta release.
+
+Also, the competition to create the title game for OpenTTD 16 is still open!
+
+<!-- more -->
+
+The latest beta includes the following:
+
+* The game no longer crashes when switching between road and tram toolbars.
+* Depots can now be built under (very tall) bridges.
+* The maximum vehicle limit has been doubled, so you can set a limit of up to 10,000 vehicles per type per company.
+* Various other fixes and improvements, see the full changelog for details.
+
+Don't forget: the [OpenTTD 16 Title Game Competition](https://www.tt-forums.net/viewtopic.php?t=92812) is open to entries until 26 July!
+This is your chance to design and later vote on the game which plays behind the main menu.
+
+If you find any bugs, please [report them here](https://github.com/OpenTTD/OpenTTD/issues/new/choose).
+
+* [Download](https://www.openttd.org/downloads/openttd-releases/testing.html)
+* [Changelog](https://cdn.openttd.org/openttd-releases/16.0-beta2/changelog.md)
+* [Bug tracker](https://github.com/OpenTTD/OpenTTD/issues)


### PR DESCRIPTION
Let's do another beta release.

I am busy Saturday, so this is dated Sunday 12 July when I should be free to push buttons.

### Long socials
```
OpenTTD 16.0-beta2 is out for testing. Fixes and features include:
* Fixed a crash when switching between rail and tram toolbars.
* Depots can now be built under (very tall) bridges.
* The maximum vehicle limit is doubled, up to 10,000 vehicles per type per company.

Full news: https://www.openttd.org/news/2026/07/12/openttd-16-0-beta2
```

### Short socials
```
OpenTTD 16.0-beta2 is out for testing. We fixed a crash, and allowed depots under bridges!
Full news: https://www.openttd.org/news/2026/07/12/openttd-16-0-beta2
```
### Image

<img width="800" height="450" alt="News-16 0-beta2" src="https://github.com/user-attachments/assets/7336400b-b8a5-49bc-8c05-194444ad94d8" />

[News-16.0-beta2.zip](https://github.com/user-attachments/files/29930500/News-16.0-beta2.zip)
